### PR TITLE
fix: resolve Dependabot alert #62 (PostCSS XSS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,7 @@
     "prettier": "^3.8.4",
     "typescript": "^6.0.3"
   },
-  "resolutions": {}
+  "resolutions": {
+    "postcss": "8.5.15"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,7 +2561,7 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.12, nanoid@^3.3.6:
+nanoid@^3.3.12:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
@@ -2743,7 +2743,7 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -2977,16 +2977,7 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31:
-  version "8.4.31"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
-  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.5.15:
+postcss@8.4.31, postcss@8.5.15, postcss@^8.5.15:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
@@ -3308,7 +3299,7 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.1:
+source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==


### PR DESCRIPTION
## Summary
This PR fixes Dependabot alert #62: PostCSS XSS via unescaped </style> in CSS stringify output.

- Alert: https://github.com/rodcast/rodcast.github.io/security/dependabot/62
- Vulnerable range: < 8.5.10
- Minimum patched version: 8.5.10

## Root Cause
next@16.2.9 pulls postcss@8.4.31 transitively, which is inside the vulnerable range.

## Changes
- Added Yarn resolution in package.json:
  - "resolutions": { "postcss": "8.5.15" }
- Regenerated yarn.lock so all postcss requests (including next's transitive request) resolve to 8.5.15.

## Verification
Commands executed locally (Node 22 via .nvmrc):

```bash
source ~/.nvm/nvm.sh && nvm use
yarn
yarn why postcss
yarn lint
yarn build
yarn audit --level high
```

Results:
- yarn why postcss: next#postcss resolves to 8.5.15
- yarn lint: passed
- yarn build: completed successfully
- yarn audit --level high: 0 vulnerabilities found

## Risk / Impact
- Low risk: no runtime code changes, dependency-resolution-only fix.
- Scope limited to package.json and yarn.lock.

## Expected Outcome
After merge and GitHub re-scan, Dependabot alert #62 should close automatically.
