### PR TITLE
docs: add project documentation (CLAUDE.md, DESIGN.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,26 +28,30 @@ src/
   styles/        # CSS Modules + global CSS
 public/          # Static assets served at the root
   .well-known/   # API/OAuth/MCP/Agent discovery metadata
+  agent/         # Static agent endpoint payloads
+  oauth/         # Static OAuth endpoint payloads
   docs/api/      # Static API docs and OpenAPI contract
   api/health     # Static health endpoint payload
 ```
 
 ### Key Files
 
-| File                                  | Role                                                        |
-| ------------------------------------- | ----------------------------------------------------------- |
-| `src/pages/_app.tsx`                  | Global styles, Google Analytics, Vercel Speed Insights      |
-| `src/pages/_document.tsx`             | SEO metadata, Open Graph/Twitter tags, JSON-LD, PWA links   |
-| `src/pages/index.tsx`                 | Main page — fetches data at build time via `getStaticProps` |
-| `src/shared/types/webmcp.d.ts`        | Ambient WebMCP navigator and tool type declarations         |
-| `src/shared/constants/paths.ts`       | External API endpoint constants                             |
-| `src/shared/utils/fetch.ts`           | Typed fetch helper with timeout and error handling          |
-| `src/shared/utils/normalizeGitHub.ts` | Normalizes and filters GitHub API responses                 |
-| `src/shared/utils/normalizeMedium.ts` | Normalizes and filters Medium RSS feed responses            |
-| `public/.well-known/api-catalog`      | API catalog for client and agent service discovery          |
-| `public/.well-known/agent-skills/`    | Agent Skills index and capability docs                      |
-| `public/docs/api/openapi.json`        | Public OpenAPI contract for static metadata endpoints       |
-| `next.config.mjs`                     | Next.js config — must preserve static export settings       |
+| File                                  | Role                                                           |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `src/pages/_app.tsx`                  | Global styles, Google Analytics, Vercel Speed Insights         |
+| `src/pages/_document.tsx`             | SEO metadata, Open Graph/Twitter tags, JSON-LD, PWA links      |
+| `src/pages/index.tsx`                 | Main page — fetches data at build time via `getStaticProps`    |
+| `src/shared/types/webmcp.d.ts`        | Ambient WebMCP navigator and tool type declarations            |
+| `src/shared/constants/paths.ts`       | External API endpoint constants                                |
+| `src/shared/utils/fetch.ts`           | Typed fetch helper with timeout and error handling             |
+| `src/shared/utils/normalizeGitHub.ts` | Normalizes and filters GitHub API responses                    |
+| `src/shared/utils/normalizeMedium.ts` | Normalizes and filters Medium RSS feed responses               |
+| `public/.well-known/api-catalog`      | API catalog for client and agent service discovery             |
+| `public/.well-known/agent-skills/`    | Agent Skills index and capability docs                         |
+| `public/docs/api/openapi.json`        | Public OpenAPI contract for static metadata endpoints          |
+| `next.config.mjs`                     | Next.js config — must preserve static export settings          |
+| `CLAUDE.md`                           | Quick reference for Claude AI (commands, aliases, constraints) |
+| `DESIGN.md`                           | Architecture decisions and rationale                           |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+Quick reference for Claude AI when working on this codebase. See `AGENTS.md` for the full project guide.
+
+## Essential Commands
+
+```bash
+nvm use          # Must run first — loads Node 24.x from .nvmrc
+yarn install     # Install dependencies
+yarn dev         # Development server (TLS validation disabled)
+yarn build       # Static export to out/
+yarn lint        # ESLint check (run before completing any task)
+yarn lint:fix    # ESLint auto-fix
+```
+
+## Critical Constraints
+
+- `output: 'export'` in `next.config.mjs` must stay — site is statically exported to GitHub Pages.
+- No SSR-only or runtime server dependencies allowed.
+- `trailingSlash: true` and `images.unoptimized: true` must not be removed.
+
+## Path Aliases (tsconfig.json)
+
+| Alias            | Resolves to               |
+| ---------------- | ------------------------- |
+| `@/*`            | `src/*`                   |
+| `@/components/*` | `src/components/*`        |
+| `@/constants/*`  | `src/shared/constants/*`  |
+| `@/interfaces/*` | `src/shared/interfaces/*` |
+| `@/types/*`      | `src/shared/types/*`      |
+| `@/utils/*`      | `src/shared/utils/*`      |
+
+Always use aliases — never relative paths.
+
+## Data Flow
+
+```
+getStaticProps (build time)
+  → fetchData (src/shared/utils/fetch.ts)
+  → normalizeGitHub / normalizeMedium (src/shared/utils/)
+  → Page props → Article component
+```
+
+## Key Conventions
+
+- Normalize all external API data before passing to components.
+- When changing an API contract, update both the interface in `src/shared/interfaces/` and its normalizer.
+- When editing `public/.well-known/agent-skills/*.md`, update the matching `sha256` in `public/.well-known/agent-skills/index.json`.
+- CSS Modules for all component styles; globals only in `src/styles/globals.css`.
+- Pre-commit hook runs lint automatically (Husky).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,7 +14,7 @@ Architecture decisions and rationale for rodcast.github.io.
 
 **Rationale:** GitHub API and the `rss2json` Medium proxy do not require authentication or personalization. Fetching at build time means the deployed HTML already contains the data — no loading spinners for primary content, no client-side API keys, and no exposure of rate-limited endpoints to end users.
 
-A 5-second timeout in `fetchData` prevents build hangs. If both APIs fail, the page renders with empty arrays rather than crashing.
+A 5-second timeout in `fetchData` prevents build hangs. If either API call fails, the page renders with empty arrays rather than crashing.
 
 ## Component Structure
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -23,7 +23,7 @@ Page (index.tsx)
 ├── Header         — name, title
 ├── Toggle         — light/dark mode
 ├── Sidebar        — avatar, bio, social links
-├── Article        — tabbed GitHub repos + Medium articles
+├── Article        — GitHub repos + Medium articles
 │   ├── GitHub     — repo cards (with GitHubSkeleton fallback)
 │   └── Medium     — article cards (with MediumSkeleton fallback)
 └── Footer

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ Architecture decisions and rationale for rodcast.github.io.
 
 **Decision:** Next.js with `output: 'export'` deployed to GitHub Pages.
 
-**Rationale:** The site is a personal portfolio that displays GitHub repositories and Medium articles. All data is public and does not change between deploys. Static export eliminates server infrastructure, reduces cost to zero, and makes the site resilient — there is no runtime to fail.
+**Rationale:** The site is a personal portfolio that displays GitHub repositories and Medium articles. All data is public and is refreshed on each deploy. Static export eliminates server infrastructure, reduces cost to zero, and makes the site resilient — there is no runtime to fail.
 
 ## Data Fetching: Build-Time Only
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,65 @@
+# DESIGN.md
+
+Architecture decisions and rationale for rodcast.github.io.
+
+## Architecture: Static Site on GitHub Pages
+
+**Decision:** Next.js with `output: 'export'` deployed to GitHub Pages.
+
+**Rationale:** The site is a personal portfolio that displays GitHub repositories and Medium articles. All data is public and does not change between deploys. Static export eliminates server infrastructure, reduces cost to zero, and makes the site resilient — there is no runtime to fail.
+
+## Data Fetching: Build-Time Only
+
+**Decision:** All external API calls happen in `getStaticProps`, not in the browser.
+
+**Rationale:** GitHub API and the `rss2json` Medium proxy do not require authentication or personalization. Fetching at build time means the deployed HTML already contains the data — no loading spinners for primary content, no client-side API keys, and no exposure of rate-limited endpoints to end users.
+
+A 5-second timeout in `fetchData` prevents build hangs. If both APIs fail, the page renders with empty arrays rather than crashing.
+
+## Component Structure
+
+```
+Page (index.tsx)
+├── Header         — name, title
+├── Toggle         — light/dark mode
+├── Sidebar        — avatar, bio, social links
+├── Article        — tabbed GitHub repos + Medium articles
+│   ├── GitHub     — repo cards (with GitHubSkeleton fallback)
+│   └── Medium     — article cards (with MediumSkeleton fallback)
+└── Footer
+```
+
+`Article` is loaded with `next/dynamic` to defer its JS bundle — it is the heaviest component and not needed for the initial paint.
+
+## Styling: CSS Modules
+
+**Decision:** One `.module.css` file per component; global styles only for resets and CSS variables.
+
+**Rationale:** Scoped class names prevent collisions without a runtime CSS-in-JS library. No build-time overhead beyond what Next.js already does. The `experimental.inlineCss` flag in `next.config.mjs` inlines critical CSS into the HTML document for faster first paint.
+
+## Discovery and Agent Metadata (`public/.well-known/`)
+
+The site exposes a set of machine-readable discovery documents:
+
+| File                         | Purpose                                 |
+| ---------------------------- | --------------------------------------- |
+| `api-catalog`                | API catalog for agent/client discovery  |
+| `agent-card.json`            | Agent identity card                     |
+| `agent-skills/`              | Agent capability index and skill docs   |
+| `mcp/`                       | Model Context Protocol server metadata  |
+| `oauth-authorization-server` | OAuth 2.0 authorization server metadata |
+| `openid-configuration`       | OpenID Connect configuration            |
+| `jwks.json`                  | JSON Web Key Set                        |
+
+These are static JSON/text files committed to `public/`. They require no server. When updating any `agent-skills/*.md`, regenerate the `sha256` in `agent-skills/index.json`.
+
+## Data Normalizers
+
+Raw API responses are never passed directly to components. Each external source has a dedicated normalizer:
+
+| Normalizer        | Input                    | Output      |
+| ----------------- | ------------------------ | ----------- |
+| `normalizeGitHub` | GitHub REST API response | `IGitHub[]` |
+| `normalizeMedium` | rss2json items array     | `IMedium[]` |
+
+If an API response shape changes, update the interface in `src/shared/interfaces/` and the normalizer together.


### PR DESCRIPTION
## Summary
- Added `CLAUDE.md` as a concise quick-reference for Claude AI: essential commands, path aliases, critical constraints, and key conventions.
- Added `DESIGN.md` documenting architectural decisions and rationale: static export, build-time data fetching, component structure, CSS Modules, and the `.well-known` discovery layer.
- Updated `AGENTS.md` to register the new files in the project structure tree and Key Files table, and added the missing `public/agent/` and `public/oauth/` directories.

## Changes
- `CLAUDE.md` *(new)* — essential commands, path alias table, data flow, static-export constraints, key conventions
- `DESIGN.md` *(new)* — rationale for static export, build-time fetching, `next/dynamic` for `Article`, CSS Modules + `inlineCss`, agent/discovery metadata overview, normalizer contract
- `AGENTS.md` *(updated)* — project structure tree now includes `public/agent/` and `public/oauth/`; Key Files table adds `CLAUDE.md` and `DESIGN.md`

## Impact
Documentation only. No source code, dependencies, or build configuration changed. Production site is unaffected.

## Test plan
- [ ] `yarn lint` passes with no errors
- [ ] `yarn build` completes and `out/` is generated correctly