### PR TITLE
chore: remove (RODCAST) alias from site name and metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file describes the project for both human contributors and AI agents. Read 
 
 ## Project Overview
 
-Personal website for Rodrigo Castilho (RODCAST).
+Personal website for Rodrigo Castilho.
 
 - **Stack:** Next.js (Pages Router) + React + TypeScript.
 - **Purpose:** Display profile content alongside the owner's latest public GitHub repositories and Medium articles.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rodrigo Castilho (RODCAST)
+# Rodrigo Castilho
 
 Personal website built with Next.js (Pages Router) and TypeScript.
 It renders profile content and fetches the latest public GitHub repositories and Medium articles at build time.

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Rodrigo Castilho (RODCAST)</title>
+    <title>Rodrigo Castilho</title>
     <description>Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.</description>
     <link>https://rodrigocastilho.com/</link>
     <atom:link href="https://rodrigocastilho.com/feed.xml" rel="self" type="application/rss+xml"/>

--- a/public/index.md
+++ b/public/index.md
@@ -1,10 +1,10 @@
 ---
-title: Rodrigo Castilho (RODCAST)
+title: Rodrigo Castilho
 description: Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.
 image: https://rodrigocastilho.com/rodrigo-castilho-rodcast_card.jpg
 ---
 
-# Rodrigo Castilho (RODCAST)
+# Rodrigo Castilho
 
 Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.
 
@@ -57,7 +57,7 @@ Read all articles at [medium.com/@rodcast](https://medium.com/@rodcast).
       "@type": "WebSite",
       "@id": "https://rodrigocastilho.com/#website",
       "url": "https://rodrigocastilho.com/",
-      "name": "Rodrigo Castilho (RODCAST)",
+      "name": "Rodrigo Castilho",
       "description": "Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.",
       "inLanguage": "en-US"
     },
@@ -65,7 +65,7 @@ Read all articles at [medium.com/@rodcast](https://medium.com/@rodcast).
       "@type": "WebPage",
       "@id": "https://rodrigocastilho.com/#webpage",
       "url": "https://rodrigocastilho.com/",
-      "name": "Rodrigo Castilho (RODCAST)",
+      "name": "Rodrigo Castilho",
       "description": "Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.",
       "inLanguage": "en-US",
       "datePublished": "2023-01-01",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Rodrigo Castilho (RODCAST)",
-  "short_name": "Rodrigo Castilho (RODCAST)",
+  "name": "Rodrigo Castilho",
+  "short_name": "Rodrigo Castilho",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#fff",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -14,7 +14,7 @@
     <changefreq>weekly</changefreq>
     <image:image>
       <image:loc>https://rodrigocastilho.com/rodrigo-castilho-rodcast_photo.jpg</image:loc>
-      <image:title>Rodrigo Castilho (RODCAST) - Staff Frontend Engineer</image:title>
+      <image:title>Rodrigo Castilho - Staff Frontend Engineer</image:title>
       <image:caption>Professional photo of Rodrigo Castilho, Staff Frontend Engineer</image:caption>
     </image:image>
     <image:image>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ export default function Sidebar() {
         priority
       />
       <h2 className={styles.name} itemProp="name">
-        Rodrigo Castilho <span itemProp="alternateName">(RODCAST)</span>
+        Rodrigo Castilho
       </h2>
       <h3 className={styles.description} itemProp="description">
         Staff Frontend Engineer and ex-@Yahoo in a serious relationship with

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 
 import '@/styles/globals.css';
 
-const title = 'Rodrigo Castilho (RODCAST)';
+const title = 'Rodrigo Castilho';
 
 /** Returns the normalised text content of a DOM node, collapsing whitespace. */
 const getText = (element: Node | null | undefined) =>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -62,7 +62,7 @@ function RobotsMeta({ robots }: RobotsMetaProps) {
 }
 
 const metadata = {
-  title: 'Rodrigo Castilho (RODCAST)',
+  title: 'Rodrigo Castilho',
   description:
     'Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.',
   keywords: [
@@ -85,7 +85,7 @@ const metadata = {
   },
   openGraph: {
     type: 'profile',
-    title: 'Rodrigo Castilho (RODCAST)',
+    title: 'Rodrigo Castilho',
     description:
       'Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.',
     image: 'https://rodrigocastilho.com/rodrigo-castilho-rodcast_card.jpg',
@@ -93,7 +93,7 @@ const metadata = {
   },
   twitter: {
     card: 'summary',
-    title: 'Rodrigo Castilho (RODCAST)',
+    title: 'Rodrigo Castilho',
     description:
       'Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.',
     image: 'https://rodrigocastilho.com/rodrigo-castilho-rodcast_card.jpg',
@@ -177,7 +177,7 @@ const structuredData = {
           'https://rodrigocastilho.com/rodrigo-castilho-rodcast_photo.jpg',
         width: 400,
         height: 400,
-        caption: 'Rodrigo Castilho (RODCAST) - Staff Frontend Engineer',
+        caption: 'Rodrigo Castilho - Staff Frontend Engineer',
       },
       jobTitle: 'Staff Frontend Engineer',
       worksFor: {
@@ -212,7 +212,7 @@ const structuredData = {
       '@type': 'WebSite',
       '@id': 'https://rodrigocastilho.com/#website',
       url: 'https://rodrigocastilho.com/',
-      name: 'Rodrigo Castilho (RODCAST)',
+      name: 'Rodrigo Castilho',
       description: metadata.description,
       publisher: { '@id': 'https://rodrigocastilho.com/#person' },
       inLanguage: 'en-US',


### PR DESCRIPTION
## Summary
- Remove the \`(RODCAST)\` nickname from all display names site-wide for a cleaner, more professional presentation

## Changes
- Drop \`(RODCAST)\` from page title, Open Graph, Twitter Card, and JSON-LD metadata
- Update PWA manifest \`name\` and \`short_name\`
- Remove \`(RODCAST)\` from RSS feed title, sitemap image title, and structured data
- Update \`Sidebar.tsx\` component to render name without the alias
- Update \`AGENTS.md\` and \`README.md\` project descriptions