### PR TITLE
chore: Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: rodcast


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` to enable GitHub Sponsors button on the repository
- Configure GitHub Sponsors with verified account (rodcast)

## Changes
- Create `.github/FUNDING.yml` with GitHub Sponsors configuration