### PR TITLE
refactor: extract WebMCP tools and simplify article rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@next/third-parties": "^16.2.9",
-    "@vercel/speed-insights": "^2.0.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,53 +1,33 @@
 import { IGitHub } from '@/interfaces/github';
 import { IMedium } from '@/interfaces/medium';
 import styles from '@/styles/article.module.css';
-import { Suspense } from 'react';
 
 import ApiErrorFallback from './ApiErrorFallback';
 import ErrorBoundary from './ErrorBoundary';
 import GitHub from './GitHub';
-import GitHubSkeleton from './GitHubSkeleton';
 import Medium from './Medium';
-import MediumSkeleton from './MediumSkeleton';
 
 interface ArticleProps {
   dataGitHub: IGitHub[];
   dataMedium: IMedium[];
-  isLoading?: boolean;
 }
 
 /** Main article component */
-export default function Article({
-  dataGitHub,
-  dataMedium,
-  isLoading = false,
-}: ArticleProps) {
+export default function Article({ dataGitHub, dataMedium }: ArticleProps) {
   return (
     <main className={styles.content}>
       <section id="github-projects">
         <ErrorBoundary
           fallback={<ApiErrorFallback title="My repositories on GitHub" />}
         >
-          {isLoading ? (
-            <GitHubSkeleton />
-          ) : (
-            <Suspense fallback={<GitHubSkeleton />}>
-              <GitHub data={dataGitHub} />
-            </Suspense>
-          )}
+          <GitHub data={dataGitHub} />
         </ErrorBoundary>
       </section>
       <section id="medium-articles" className={styles.medium_articles}>
         <ErrorBoundary
           fallback={<ApiErrorFallback title="My articles on Medium" />}
         >
-          {isLoading ? (
-            <MediumSkeleton />
-          ) : (
-            <Suspense fallback={<MediumSkeleton />}>
-              <Medium data={dataMedium} />
-            </Suspense>
-          )}
+          <Medium data={dataMedium} />
         </ErrorBoundary>
       </section>
     </main>

--- a/src/components/GitHub.tsx
+++ b/src/components/GitHub.tsx
@@ -1,6 +1,5 @@
 import { IGitHub } from '@/interfaces/index';
 import styles from '@/styles/article.module.css';
-import { Fragment } from 'react';
 
 interface GitHubProps {
   data?: IGitHub[];
@@ -29,21 +28,19 @@ export default function GitHub({ data }: GitHubProps) {
       {Array.isArray(repos) && (
         <ol className={styles.list}>
           {repos.map(({ node_id, name, html_url, description }) => (
-            <Fragment key={node_id}>
-              <li className={styles.item}>
-                <span className={styles.subtitle}>
-                  <a
-                    href={html_url}
-                    title={name}
-                    className={styles.url}
-                    rel="external"
-                  >
-                    {name}
-                  </a>
-                </span>
-                <span className={styles.description}>{description}</span>
-              </li>
-            </Fragment>
+            <li key={node_id} className={styles.item}>
+              <span className={styles.subtitle}>
+                <a
+                  href={html_url}
+                  title={name}
+                  className={styles.url}
+                  rel="external"
+                >
+                  {name}
+                </a>
+              </span>
+              <span className={styles.description}>{description}</span>
+            </li>
           ))}
         </ol>
       )}

--- a/src/components/Medium.tsx
+++ b/src/components/Medium.tsx
@@ -1,6 +1,5 @@
 import { IMedium } from '@/interfaces/index';
 import styles from '@/styles/article.module.css';
-import { Fragment } from 'react';
 
 interface MediumProps {
   data?: IMedium[];
@@ -39,31 +38,29 @@ export default function Medium({ data }: MediumProps) {
               : 'Date unavailable';
 
             return (
-              <Fragment key={guid}>
-                <li className={styles.item}>
-                  <span className={styles.subtitle}>
-                    <a
-                      href={link}
-                      title={title}
-                      className={styles.url}
-                      rel="external"
-                    >
-                      {title}
-                    </a>
-                  </span>
-                  {isValidPublishedDate ? (
-                    <time
-                      className={styles.time}
-                      dateTime={publishedDate.toISOString()}
-                    >
-                      {dateLabel}
-                    </time>
-                  ) : (
-                    <span className={styles.time}>{dateLabel}</span>
-                  )}
-                  <span className={styles.description}>{content}</span>
-                </li>
-              </Fragment>
+              <li key={guid} className={styles.item}>
+                <span className={styles.subtitle}>
+                  <a
+                    href={link}
+                    title={title}
+                    className={styles.url}
+                    rel="external"
+                  >
+                    {title}
+                  </a>
+                </span>
+                {isValidPublishedDate ? (
+                  <time
+                    className={styles.time}
+                    dateTime={publishedDate.toISOString()}
+                  >
+                    {dateLabel}
+                  </time>
+                ) : (
+                  <span className={styles.time}>{dateLabel}</span>
+                )}
+                <span className={styles.description}>{content}</span>
+              </li>
             );
           })}
         </ol>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import type { WebMCPTool } from '@/types/webmcp';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -8,195 +7,6 @@ import '@/styles/globals.css';
 
 const title = 'Rodrigo Castilho';
 
-/** Returns the normalised text content of a DOM node, collapsing whitespace. */
-const getText = (element: Node | null | undefined) =>
-  (element?.textContent ?? '').trim().replace(/\s+/g, ' ');
-
-/** Reads the profile summary and social links from the about section DOM. */
-const getProfileSummary = () => {
-  const about = document.getElementById('about');
-  const links = Array.from(about?.querySelectorAll('a[href]') ?? []).map(
-    (anchor) => ({
-      label: getText(anchor),
-      url: anchor.getAttribute('href') ?? '',
-    })
-  );
-
-  return {
-    name: getText(about?.querySelector('h2')),
-    description: getText(about?.querySelector('h3')),
-    section: 'about',
-    links,
-  };
-};
-
-/** Returns up to `limit` GitHub project entries from the rendered project list. */
-const listGitHubProjects = (limit: number) => {
-  const items = Array.from(
-    document.querySelectorAll('#github-projects ol li')
-  ).map((item) => {
-    const link = item.querySelector('a[href]');
-
-    return {
-      name: getText(link),
-      url: link?.getAttribute('href') ?? '',
-      description: getText(item.querySelector('span:last-child')),
-    };
-  });
-
-  return items.slice(0, limit);
-};
-
-/** Returns up to `limit` Medium article entries from the rendered articles list. */
-const listMediumArticles = (limit: number) => {
-  const items = Array.from(
-    document.querySelectorAll('#medium-articles ol li')
-  ).map((item) => {
-    const link = item.querySelector('a[href]');
-    const time = item.querySelector('time');
-    const description = item.querySelector('span:last-child');
-
-    return {
-      title: getText(link),
-      url: link?.getAttribute('href') ?? '',
-      publishedAt: time?.getAttribute('datetime') ?? getText(time),
-      summary: getText(description),
-    };
-  });
-
-  return items.slice(0, limit);
-};
-
-/** Builds the WebMCP tool definitions backed by the current DOM state. */
-const buildWebMCPTools = (): WebMCPTool[] => [
-  {
-    name: 'get-profile-summary',
-    title: 'Get profile summary',
-    description:
-      'Returns the visible profile summary and social links from the about section.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      additionalProperties: false,
-    },
-    annotations: {
-      readOnlyHint: true,
-    },
-    execute: () => Promise.resolve(getProfileSummary()),
-  },
-  {
-    name: 'navigate-to-section',
-    title: 'Navigate to section',
-    description:
-      'Scrolls the page to a known section: about, github-projects, or medium-articles.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        section: {
-          type: 'string',
-          enum: ['about', 'github-projects', 'medium-articles'],
-          description: 'The section id to navigate to.',
-        },
-      },
-      required: ['section'],
-      additionalProperties: false,
-    },
-    execute: (input) => {
-      const section = typeof input?.section === 'string' ? input.section : '';
-      const target = document.getElementById(section);
-
-      if (!target) {
-        return Promise.resolve({
-          ok: false,
-          error: 'unknown_section',
-        });
-      }
-
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      window.history.replaceState(null, '', `#${section}`);
-
-      return Promise.resolve({
-        ok: true,
-        section,
-        title: getText(target.querySelector('header, h1, h2, h3')) || section,
-      });
-    },
-  },
-  {
-    name: 'list-github-projects',
-    title: 'List GitHub projects',
-    description:
-      'Returns the GitHub repositories currently rendered in the projects section.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        limit: {
-          type: 'number',
-          minimum: 1,
-          maximum: 20,
-          default: 6,
-          description: 'Maximum number of repositories to return.',
-        },
-      },
-      additionalProperties: false,
-    },
-    annotations: {
-      readOnlyHint: true,
-    },
-    execute: (input) => {
-      const limit =
-        typeof input?.limit === 'number' && input.limit > 0
-          ? Math.min(input.limit, 20)
-          : 6;
-
-      return Promise.resolve(listGitHubProjects(limit));
-    },
-  },
-  {
-    name: 'list-medium-articles',
-    title: 'List Medium articles',
-    description:
-      'Returns the Medium articles currently rendered in the articles section.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        limit: {
-          type: 'number',
-          minimum: 1,
-          maximum: 10,
-          default: 5,
-          description: 'Maximum number of articles to return.',
-        },
-      },
-      additionalProperties: false,
-    },
-    annotations: {
-      readOnlyHint: true,
-    },
-    execute: (input) => {
-      const limit =
-        typeof input?.limit === 'number' && input.limit > 0
-          ? Math.min(input.limit, 10)
-          : 5;
-
-      return Promise.resolve(listMediumArticles(limit));
-    },
-  },
-];
-
-/** Keeps only the canonical WebMCP registerTool properties for stricter runtimes. */
-const toRegisterToolPayload = ({
-  name,
-  description,
-  inputSchema,
-  execute,
-}: WebMCPTool): WebMCPTool => ({
-  name,
-  description,
-  inputSchema,
-  execute,
-});
-
 /** Main app component */
 function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
@@ -204,15 +14,16 @@ function App({ Component, pageProps }: AppProps) {
       return () => undefined;
     }
 
-    const tools = buildWebMCPTools();
     const abortController = new AbortController();
 
     /** Registers WebMCP tools with all available APIs; returns true when any path succeeds. */
     const registerTools = async () => {
+      const { buildWebMCPTools, toRegisterToolPayload } =
+        await import('@/utils/webmcpTools');
       const signal = abortController.signal;
       const navCtx = navigator.modelContext;
       const docCtx = document.modelContext;
-      const canonicalTools = tools.map(toRegisterToolPayload);
+      const canonicalTools = buildWebMCPTools().map(toRegisterToolPayload);
       let didRegister = false;
 
       if (navCtx?.registerTool) {

--- a/src/shared/utils/webmcpTools.ts
+++ b/src/shared/utils/webmcpTools.ts
@@ -1,0 +1,190 @@
+import type { WebMCPTool } from '@/types/webmcp';
+
+/** Returns the normalised text content of a DOM node, collapsing whitespace. */
+const getText = (element: Node | null | undefined) =>
+  (element?.textContent ?? '').trim().replace(/\s+/g, ' ');
+
+/** Reads the profile summary and social links from the about section DOM. */
+const getProfileSummary = () => {
+  const about = document.getElementById('about');
+  const links = Array.from(about?.querySelectorAll('a[href]') ?? []).map(
+    (anchor) => ({
+      label: getText(anchor),
+      url: anchor.getAttribute('href') ?? '',
+    })
+  );
+
+  return {
+    name: getText(about?.querySelector('h2')),
+    description: getText(about?.querySelector('h3')),
+    section: 'about',
+    links,
+  };
+};
+
+/** Returns up to `limit` GitHub project entries from the rendered project list. */
+const listGitHubProjects = (limit: number) => {
+  const items = Array.from(
+    document.querySelectorAll('#github-projects ol li')
+  ).map((item) => {
+    const link = item.querySelector('a[href]');
+
+    return {
+      name: getText(link),
+      url: link?.getAttribute('href') ?? '',
+      description: getText(item.querySelector('span:last-child')),
+    };
+  });
+
+  return items.slice(0, limit);
+};
+
+/** Returns up to `limit` Medium article entries from the rendered articles list. */
+const listMediumArticles = (limit: number) => {
+  const items = Array.from(
+    document.querySelectorAll('#medium-articles ol li')
+  ).map((item) => {
+    const link = item.querySelector('a[href]');
+    const time = item.querySelector('time');
+    const description = item.querySelector('span:last-child');
+
+    return {
+      title: getText(link),
+      url: link?.getAttribute('href') ?? '',
+      publishedAt: time?.getAttribute('datetime') ?? getText(time),
+      summary: getText(description),
+    };
+  });
+
+  return items.slice(0, limit);
+};
+
+/** Builds the WebMCP tool definitions backed by the current DOM state. */
+export const buildWebMCPTools = (): WebMCPTool[] => [
+  {
+    name: 'get-profile-summary',
+    title: 'Get profile summary',
+    description:
+      'Returns the visible profile summary and social links from the about section.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+    execute: () => Promise.resolve(getProfileSummary()),
+  },
+  {
+    name: 'navigate-to-section',
+    title: 'Navigate to section',
+    description:
+      'Scrolls the page to a known section: about, github-projects, or medium-articles.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        section: {
+          type: 'string',
+          enum: ['about', 'github-projects', 'medium-articles'],
+          description: 'The section id to navigate to.',
+        },
+      },
+      required: ['section'],
+      additionalProperties: false,
+    },
+    execute: (input) => {
+      const section = typeof input?.section === 'string' ? input.section : '';
+      const target = document.getElementById(section);
+
+      if (!target) {
+        return Promise.resolve({
+          ok: false,
+          error: 'unknown_section',
+        });
+      }
+
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      window.history.replaceState(null, '', `#${section}`);
+
+      return Promise.resolve({
+        ok: true,
+        section,
+        title: getText(target.querySelector('header, h1, h2, h3')) || section,
+      });
+    },
+  },
+  {
+    name: 'list-github-projects',
+    title: 'List GitHub projects',
+    description:
+      'Returns the GitHub repositories currently rendered in the projects section.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 20,
+          default: 6,
+          description: 'Maximum number of repositories to return.',
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+    execute: (input) => {
+      const limit =
+        typeof input?.limit === 'number' && input.limit > 0
+          ? Math.min(input.limit, 20)
+          : 6;
+
+      return Promise.resolve(listGitHubProjects(limit));
+    },
+  },
+  {
+    name: 'list-medium-articles',
+    title: 'List Medium articles',
+    description:
+      'Returns the Medium articles currently rendered in the articles section.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 10,
+          default: 5,
+          description: 'Maximum number of articles to return.',
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+    execute: (input) => {
+      const limit =
+        typeof input?.limit === 'number' && input.limit > 0
+          ? Math.min(input.limit, 10)
+          : 5;
+
+      return Promise.resolve(listMediumArticles(limit));
+    },
+  },
+];
+
+/** Keeps only the canonical WebMCP registerTool properties for stricter runtimes. */
+export const toRegisterToolPayload = ({
+  name,
+  description,
+  inputSchema,
+  execute,
+}: WebMCPTool): WebMCPTool => ({
+  name,
+  description,
+  inputSchema,
+  execute,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,11 +645,6 @@
     "@typescript-eslint/types" "8.61.1"
     eslint-visitor-keys "^5.0.0"
 
-"@vercel/speed-insights@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-2.0.0.tgz#76e7ce61ce5db6f006a4991b0f60bd12d7c61b7c"
-  integrity sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
## Context
This change is a focused cleanup of client-side app wiring and article list rendering after introducing WebMCP support. The previous implementation kept all WebMCP tool definition logic inside `src/pages/_app.tsx`, which made the app shell file very large and harder to reason about.

## Decisions
- Extracted WebMCP tool definitions and helper functions into a dedicated utility module (`src/shared/utils/webmcpTools.ts`).
- Kept lazy loading (`await import('@/utils/webmcpTools')`) in `_app.tsx` to avoid eagerly loading DOM-dependent logic before hydration.
- Removed unnecessary `Fragment` wrappers in list components and moved stable keys directly to `li` elements.
- Removed Suspense/skeleton branching from `Article` for GitHub/Medium lists, since these sections already receive build-time data via props and don’t rely on client-side suspense boundaries.
- Removed `@vercel/speed-insights` from runtime dependencies since it is no longer used in code.

## Changes
- Refactored `_app.tsx` to keep only registration orchestration and dynamically import WebMCP tool builders.
- Added `src/shared/utils/webmcpTools.ts` containing:
  - DOM text normalization helpers
  - profile summary extraction
  - GitHub/Medium list extraction tools
  - canonical payload adapter for stricter registerTool implementations
- Simplified `src/components/GitHub.tsx` and `src/components/Medium.tsx` list rendering by removing redundant `Fragment` wrappers.
- Simplified `src/components/Article.tsx` by removing `isLoading` + Suspense/skeleton branch logic and directly rendering child sections.
- Updated dependency lockfile by removing `@vercel/speed-insights`.

## Impact
- Improves maintainability by separating WebMCP tool concerns from the app shell.
- Reduces component complexity and rendered node depth in article lists.
- Keeps static-export compatibility unchanged (`output: 'export'`, `trailingSlash`, and `images.unoptimized` are untouched).
- No API contract changes and no user-facing route changes.

## Testing and Validation
- `yarn lint` ✅
- `yarn build` ✅

Build note:
- During SSG data fetching, the existing fallback path logs `TypeError: fetch failed` with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` in this local environment. The build still completes successfully and generates static pages as expected.

## Risk Assessment
- Low risk: mostly refactor + render simplification without changing data contracts.
- Main behavioral watchpoint: WebMCP registration timing remains retry-based and now depends on dynamic import resolution (covered by existing retry loop and abort handling).
