### PR TITLE
chore: add llms.txt endpoint and explicit markdown headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -45,6 +45,9 @@
   Content-Type: text/markdown; charset=utf-8
   x-markdown-tokens: 640
 
+/llms.txt
+  Content-Type: text/markdown; charset=utf-8
+
 # Cache static assets for 1 year (long-lived immutable assets)
 /*.js
   Cache-Control: public, max-age=31536000, immutable

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,31 @@
+# Rodrigo Castilho
+
+> Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym. Personal site exposing public profile, projects, and articles as agent-friendly content.
+
+The site is a statically exported Next.js application. Project and article data are fetched at build time from the GitHub REST API and the Medium RSS feed. A markdown representation of the homepage is available via content negotiation (`Accept: text/markdown` on `/`) or directly at `/index.md`.
+
+## Content
+
+- [Homepage (Markdown)](https://rodrigocastilho.com/index.md): Profile summary, projects, and articles with embedded schema.org JSON-LD.
+- [RSS Feed](https://rodrigocastilho.com/feed.xml): Site feed.
+- [Sitemap](https://rodrigocastilho.com/sitemap.xml): List of indexable URLs.
+
+## API
+
+- [OpenAPI Specification](https://rodrigocastilho.com/docs/api/openapi.json): OpenAPI 3.1 description of the public endpoints.
+- [API Documentation](https://rodrigocastilho.com/docs/api/): Human-readable API docs.
+- [API Documentation (Markdown)](https://rodrigocastilho.com/docs/api.md): Agent-friendly API docs.
+- [API Catalog](https://rodrigocastilho.com/.well-known/api-catalog): RFC 9727 linkset advertising API discovery endpoints.
+
+## Agents
+
+- [Agent Card](https://rodrigocastilho.com/.well-known/agent-card.json): Agent metadata for this site.
+- [Agent Skills Index](https://rodrigocastilho.com/.well-known/agent-skills/index.json): Catalog of agent skills (markdown negotiation, API discovery, WebMCP tools, auth).
+- [MCP Server Card](https://rodrigocastilho.com/.well-known/mcp/server-card.json): Model Context Protocol server descriptor.
+
+## Social
+
+- [GitHub](https://github.com/rodcast)
+- [Twitter](https://twitter.com/rodcast)
+- [LinkedIn](https://www.linkedin.com/in/rodrigocastilho)
+- [Medium](https://medium.com/@rodcast)

--- a/vercel.json
+++ b/vercel.json
@@ -167,6 +167,15 @@
           "value": "640"
         }
       ]
+    },
+    {
+      "source": "/llms.txt",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add a dedicated `public/llms.txt` document describing site, API, and agent-discovery resources for LLM/agent consumers.
- Ensure `/llms.txt` is served with `text/markdown; charset=utf-8` in both static hosting header configs.
- Keep header behavior aligned across GitHub Pages (`public/_headers`) and Vercel (`vercel.json`) to avoid environment drift.

## Context
- The repository already exposed related machine-readable resources (`/index.md`, API catalog, OpenAPI docs, and `.well-known` metadata), but lacked a first-class `/llms.txt` endpoint.
- Without explicit content-type mapping, platforms can infer less specific mime types and reduce interoperability for agent ingestion.

## Decisions
- Chose to publish a standalone `public/llms.txt` instead of overloading existing docs so clients can discover a single canonical agent-oriented entry point.
- Added headers in both hosting config files to preserve parity between deployment targets.
- Used markdown content with stable links to existing public endpoints instead of introducing new runtime routes, keeping static export constraints intact.

## Changes
- Added new file:
  - `public/llms.txt`
- Updated header rules:
  - `public/_headers`: added `/llms.txt` content-type mapping
  - `vercel.json`: added `/llms.txt` content-type mapping

## Impact
- Positive:
  - Improves discoverability for LLM/agent tooling.
  - Standardizes response metadata for deterministic parsing.
  - No runtime or server-side dependency changes; remains fully static-export compatible.
- Risk:
  - Low. Change is additive and scoped to one new static file plus header metadata.

## Testing & Validation
- `nvm use` (Node `v24.17.0` from `.nvmrc`)
- `yarn lint` passed
- Pre-commit hooks executed successfully:
  - ESLint passed
  - Prettier `--check` passed

## Rollout Notes
- No migration steps required.
- Deploying this branch will expose `/llms.txt` and correct response headers on supported hosts.