### PR TITLE
chore: align discovery metadata, security policy, and CI quality gates

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -73,6 +73,10 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Lint and format check
+        run: |
+          ${{ steps.detect-package-manager.outputs.manager }} lint
+          ${{ steps.detect-package-manager.outputs.runner }} prettier --check .
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       # - name: Static HTML export with Next.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,14 @@ public/          # Static assets served at the root
 - **Deploy target:** GitHub Pages via `actions/deploy-pages`.
 - A `vercel.json` file exists but the canonical production deployment is GitHub Pages.
 
+> **Hosting caveat:** GitHub Pages serves static files only — it does **not**
+> apply `vercel.json` rewrites or the `public/_headers` rules (`Link`, `Vary`,
+> `Cache-Control`, content negotiation). Those files only take effect on a host
+> that honors them (Vercel, Cloudflare Pages, Netlify). On GitHub Pages the
+> agent/discovery surface is the static files under `public/` plus the `<link>`
+> tags in `src/pages/_document.tsx`; `Accept: text/markdown` negotiation is not
+> active, so fetch `/index.md` directly.
+
 ---
 
 ## Development Conventions
@@ -130,7 +138,7 @@ public/          # Static assets served at the root
 
 - Keep `.well-known` discovery documents internally consistent (`api-catalog`, `agent-card.json`, `mcp.json`, `mcp/server-card.json`, OAuth/OIDC metadata, and agent-skills index).
 - When updating any `public/.well-known/agent-skills/*.md` file, refresh the matching `sha256` entry in `public/.well-known/agent-skills/index.json`.
-- Preserve API discovery links exposed in both `src/pages/_document.tsx` and `public/_headers`.
+- Preserve API discovery links exposed in `src/pages/_document.tsx` (the discovery surface honored on GitHub Pages) and keep them consistent with the `Link` header in `public/_headers`/`vercel.json` (used only on non-Pages hosts).
 
 ### Error Handling
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,6 +61,8 @@ The site exposes a set of machine-readable discovery documents:
 
 These are static JSON/text files committed to `public/`. They require no server. When updating any `agent-skills/*.md`, regenerate the `sha256` in `agent-skills/index.json`.
 
+**Host limitation:** discovery here relies on static files and the `<link>` tags in `_document.tsx`. The HTTP-header layer (`Link`, `Vary`, `Cache-Control`, and `Accept: text/markdown` negotiation defined in `vercel.json` and `public/_headers`) is **not honored by GitHub Pages** — it applies only if the site is served from Vercel/Cloudflare Pages/Netlify. On GitHub Pages, fetch markdown directly at `/index.md`.
+
 ## Data Normalizers
 
 Raw API responses are never passed directly to components. Each external source has a dedicated normalizer:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rodrigo Castilho
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project or on
+<https://rodrigocastilho.com/>, please report it privately.
+
+- **Email:** rodcast@gmail.com
+- **Languages:** English, Portuguese
+
+Please include enough detail to reproduce the issue (affected URL or file,
+steps, and impact). Do not open a public GitHub issue for security reports.
+
+A machine-readable version of this contact information is published at
+[`/.well-known/security.txt`](https://rodrigocastilho.com/.well-known/security.txt)
+(RFC 9116).
+
+## Scope
+
+This is a statically exported personal website hosted on GitHub Pages. The
+`public/.well-known/` directory exposes public discovery metadata (OAuth/OIDC,
+MCP, agent, and API descriptors) for crawlers and agents; reports about those
+endpoints are welcome.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "engines": {
     "node": "24.x"
   },

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -13,7 +13,7 @@
       "type": "representation",
       "description": "Publishes a markdown representation of the homepage for agents.",
       "url": "https://rodrigocastilho.com/.well-known/agent-skills/markdown-negotiation.md",
-      "sha256": "609c8470dfbee9123931cda41eda3e744c947d14f34560e53c079652b3d17ca5"
+      "sha256": "781023e1d165d50962423c27fa07be1be9eb2d2ae13c150a946f569f48b1f8c0"
     },
     {
       "name": "auth-discovery",

--- a/public/.well-known/agent-skills/markdown-negotiation.md
+++ b/public/.well-known/agent-skills/markdown-negotiation.md
@@ -1,23 +1,26 @@
 # Markdown Negotiation
 
-Supports `Accept: text/markdown` content negotiation so agents can request
-a markdown representation of the homepage.
+Provides a markdown representation of the homepage so agents can retrieve
+clean, token-efficient content.
 
-## Content Negotiation
+## Markdown Representation
 
-Send `Accept: text/markdown` with a request to `/` and receive the markdown
-version of the homepage with `Content-Type: text/markdown`.
-
-## Endpoint
+Fetch the markdown version of the homepage directly:
 
 - Markdown homepage: /index.md
 
-## Headers
+It is also advertised in the HTML `<head>`:
 
-- `Content-Type: text/markdown; charset=utf-8`
-- `x-markdown-tokens: enabled`
+- `<link rel="alternate" type="text/markdown" href="/index.md">`
+
+## Content Negotiation
+
+`Accept: text/markdown` negotiation on `/` is configured in the repository
+(`vercel.json` rewrite plus `Vary: Accept`) for hosts that honor those rules.
+The site is currently served from GitHub Pages, which does not apply custom
+rewrites or response headers, so request `/index.md` directly there.
 
 ## Notes
 
-- HTML remains the default browser representation.
-- Requests with `Accept: text/markdown` are transparently served `/index.md`.
+- HTML remains the default representation at `/`.
+- The markdown copy mirrors the homepage profile, projects, and articles.

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -12,6 +12,6 @@
     "url": "https://rodrigocastilho.com/docs/api/openapi.json"
   },
   "logo_url": "https://rodrigocastilho.com/rodrigo-castilho-rodcast_card.jpg",
-  "contact_email": "hello@rodrigocastilho.com",
+  "contact_email": "rodcast@gmail.com",
   "legal_info_url": "https://rodrigocastilho.com/"
 }

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:security@rodrigocastilho.com
+Contact: mailto:rodcast@gmail.com
 Expires: 2026-10-08T00:00:00.000Z
 Preferred-Languages: en, pt
 Canonical: https://rodrigocastilho.com/.well-known/security.txt

--- a/public/auth.md
+++ b/public/auth.md
@@ -210,4 +210,4 @@ Two independent layers:
 
 ## Contact
 
-Integration questions: <mailto:security@rodrigocastilho.com>
+Integration questions: <mailto:rodcast@gmail.com>

--- a/src/components/ApiErrorFallback.tsx
+++ b/src/components/ApiErrorFallback.tsx
@@ -15,7 +15,7 @@ export default function ApiErrorFallback({
 }: ApiErrorFallbackProps) {
   return (
     <article className={articleStyles.content}>
-      <header className={articleStyles.title}>{title}</header>
+      <h2 className={articleStyles.title}>{title}</h2>
       <div className={styles.error_container}>
         <p className={articleStyles.description}>{message}</p>
         {onRetry && (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -88,6 +88,7 @@ function App({ Component, pageProps }: AppProps) {
     <>
       <Head>
         <title>{title}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -92,7 +92,7 @@ const metadata = {
     url: 'https://rodrigocastilho.com/',
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Rodrigo Castilho',
     description:
       'Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming languages and the gym.',


### PR DESCRIPTION
## Context
This PR consolidates repository metadata, agent/discovery documentation, and baseline quality checks so the public discovery surface reflects how the site is actually hosted (GitHub Pages static export), while also standardizing contact/security information across machine-readable and human-readable endpoints.

## Decisions
- Documented a hosting constraint explicitly: GitHub Pages serves static files and does not apply `vercel.json` rewrites or `public/_headers` response-header negotiation.
- Updated markdown-negotiation guidance to prefer direct `/index.md` fetch on GitHub Pages while still documenting negotiation behavior for hosts that support rewrites/headers.
- Standardized security/contact email to `rodcast@gmail.com` across discovery/security artifacts.
- Added explicit MIT licensing metadata in `package.json` and introduced top-level `LICENSE` and `SECURITY.md` policy documents.
- Hardened CI quality gates by running lint and Prettier check in GitHub Actions before build.
- Applied two small SEO/accessibility correctness improvements in app/document components (`viewport` meta and `twitter:card` type) and semantic heading in API error fallback.

## Changes
- CI / quality gates
  - Added lint and format check step in `.github/workflows/nextjs.yml`.
- Documentation / architecture clarity
  - Added hosting-behavior caveats in `AGENTS.md` and `DESIGN.md`.
  - Updated `public/.well-known/agent-skills/markdown-negotiation.md` semantics and guidance.
  - Refreshed checksum in `public/.well-known/agent-skills/index.json` to match the markdown skill doc update.
- Security / contact consistency
  - Updated contact email in `public/.well-known/ai-plugin.json`, `public/.well-known/security.txt`, and `public/auth.md`.
  - Added `SECURITY.md` policy and `LICENSE` (MIT), and set `package.json` `license` field.
- Metadata / semantic fixes
  - Added viewport meta in `src/pages/_app.tsx`.
  - Updated Twitter card type to `summary_large_image` in `src/pages/_document.tsx`.
  - Replaced non-semantic title header element with `h2` in `src/components/ApiErrorFallback.tsx`.

## Impact
- Positive:
  - Discovery and agent consumers receive clearer, host-accurate instructions.
  - Security reporting path is consistent across all published metadata.
  - CI catches style/lint regressions earlier.
  - Social preview metadata and semantic markup are improved.
- Risk level: Low.
- Potential side effects:
  - Any automation expecting the old security/contact email must update to `rodcast@gmail.com`.

## Testing
- Local validation executed:
  - `nvm use`
  - `yarn lint`
  - `npx prettier --check .`
- Commit hooks validation executed automatically on commit:
  - ESLint
  - Prettier check

## Validation Results
- `yarn lint`: passed
- `npx prettier --check .`: passed
- Branch diff scope: 14 files changed, focused on metadata/docs/CI and minor semantic fixes.

## Deployment / Runtime Notes
- No runtime server dependencies introduced.
- Static-export constraints remain intact (`output: 'export'`, `trailingSlash: true`, `images.unoptimized: true`).
- Changes are compatible with GitHub Pages deployment model.
