### PR TITLE
feat: cookie consent banner with Google Consent Mode v2

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -22,8 +22,10 @@ const CONSENT_STATE: Record<ConsentChoice, Record<string, ConsentChoice>> = {
 
 /** Pushes a Google Consent Mode v2 update for the user's choice. */
 const updateConsent = (choice: ConsentChoice) => {
-  const w = window as unknown as { gtag?: (...args: unknown[]) => void };
-  w.gtag?.('consent', 'update', CONSENT_STATE[choice]);
+  const globalScope = window as unknown as {
+    gtag?: (...args: unknown[]) => void;
+  };
+  globalScope.gtag?.('consent', 'update', CONSENT_STATE[choice]);
 };
 
 /**

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,0 +1,91 @@
+import styles from '@/styles/cookieConsent.module.css';
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'cookie-consent';
+
+type ConsentChoice = 'granted' | 'denied';
+
+const CONSENT_STATE: Record<ConsentChoice, Record<string, ConsentChoice>> = {
+  granted: {
+    ad_storage: 'granted',
+    analytics_storage: 'granted',
+    ad_user_data: 'granted',
+    ad_personalization: 'granted',
+  },
+  denied: {
+    ad_storage: 'denied',
+    analytics_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+  },
+};
+
+/** Pushes a Google Consent Mode v2 update for the user's choice. */
+const updateConsent = (choice: ConsentChoice) => {
+  const w = window as unknown as { gtag?: (...args: unknown[]) => void };
+  w.gtag?.('consent', 'update', CONSENT_STATE[choice]);
+};
+
+/**
+ * Minimal cookie consent banner backed by Google Consent Mode v2.
+ * Defaults are denied (set in `_document`); this banner records the user's
+ * choice in localStorage and updates consent accordingly.
+ */
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        setVisible(true);
+      }
+    } catch {
+      // localStorage unavailable (e.g. privacy mode); show the banner anyway.
+      setVisible(true);
+    }
+  }, []);
+
+  const choose = useCallback((choice: ConsentChoice) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, choice);
+    } catch {
+      // Ignore storage failures; consent still applies for this session.
+    }
+    updateConsent(choice);
+    setVisible(false);
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.banner}
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie consent"
+    >
+      <p className={styles.text}>
+        This site uses Google Analytics to measure traffic. Analytics cookies
+        stay off until you accept.
+      </p>
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={`${styles.button} ${styles.reject}`}
+          onClick={() => choose('denied')}
+        >
+          Reject
+        </button>
+        <button
+          type="button"
+          className={`${styles.button} ${styles.accept}`}
+          onClick={() => choose('granted')}
+        >
+          Accept
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import CookieConsent from '@/components/CookieConsent';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
@@ -96,6 +97,7 @@ function App({ Component, pageProps }: AppProps) {
       <main>
         <Component {...pageProps} />
       </main>
+      {process.env.NEXT_PUBLIC_GA_TRACKING_ID && <CookieConsent />}
     </>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -325,7 +325,8 @@ class MyDocument extends Document {
             <script
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{
-                __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',analytics_storage:'denied',ad_user_data:'denied',ad_personalization:'denied'});try{if(localStorage.getItem('cookie-consent')==='granted'){gtag('consent','update',{ad_storage:'granted',analytics_storage:'granted',ad_user_data:'granted',ad_personalization:'granted'});}}catch(e){}`,
+                __html:
+                  "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',analytics_storage:'denied',ad_user_data:'denied',ad_personalization:'denied'});try{if(localStorage.getItem('cookie-consent')==='granted'){gtag('consent','update',{ad_storage:'granted',analytics_storage:'granted',ad_user_data:'granted',ad_personalization:'granted'});}}catch(e){}",
               }}
             />
           )}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -319,6 +319,17 @@ class MyDocument extends Document {
           <link rel="dns-prefetch" href="//www.google-analytics.com" />
           <link rel="dns-prefetch" href="//www.googletagmanager.com" />
 
+          {/* Google Consent Mode v2 defaults (denied until the user accepts).
+              Runs before Google Analytics so consent state is queued first. */}
+          {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
+            <script
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: `window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',analytics_storage:'denied',ad_user_data:'denied',ad_personalization:'denied'});try{if(localStorage.getItem('cookie-consent')==='granted'){gtag('consent','update',{ad_storage:'granted',analytics_storage:'granted',ad_user_data:'granted',ad_personalization:'granted'});}}catch(e){}`,
+              }}
+            />
+          )}
+
           {/* Additional SEO Links */}
           <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
           <link

--- a/src/styles/cookieConsent.module.css
+++ b/src/styles/cookieConsent.module.css
@@ -1,0 +1,67 @@
+.banner {
+  position: fixed;
+  bottom: var(--space-x-1);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  width: calc(100% - var(--space-x-2));
+  max-width: 640px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-x-1);
+  padding: var(--space-x-1);
+  color: var(--secondary-color);
+  background-color: var(--tertiary-color);
+  border: 1px solid var(--secondary-color);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 15%);
+}
+
+.text {
+  margin: var(--space-x-0);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-x-0_5);
+  flex-shrink: 0;
+}
+
+.button {
+  padding: var(--space-x-0_5) var(--space-x-1);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--secondary-color);
+  transition: var(--transition-200);
+}
+
+.accept {
+  color: var(--primary-color);
+  background-color: var(--secondary-color);
+}
+
+.reject {
+  color: var(--secondary-color);
+  background-color: transparent;
+}
+
+.accept:hover,
+.reject:hover {
+  opacity: 0.85;
+}
+
+@media (max-width: 640px) {
+  .banner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions {
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **free, dependency-free** cookie consent banner backed by **Google Consent Mode v2**, so Google Analytics only stores cookies / collects after the visitor accepts. Fits a static GitHub Pages portfolio — no SaaS, no external consent script, no account.

## How it works

1. **Defaults to denied** — `_document.tsx` sets Consent Mode v2 defaults (`ad_storage`, `analytics_storage`, `ad_user_data`, `ad_personalization` = `denied`) in an inline head script that runs **before** the GA tag initializes, so the denied state is queued ahead of GA's `config`.
2. **Banner** — `CookieConsent.tsx` renders a small Accept / Reject banner when no prior choice exists. On choice it records `cookie-consent` in `localStorage` and pushes a `gtag('consent','update', …)`.
3. **Returning visitors** — the head script reads `localStorage`; if previously `granted`, it pushes a consent `update` to granted on load, so they aren't re-prompted and analytics works immediately.
4. **Gated on GA** — both the consent script and banner only render when `NEXT_PUBLIC_GA_TRACKING_ID` is set (no GA → no cookies → no banner).

## Files

| File | Change |
| --- | --- |
| `src/pages/_document.tsx` | Inline Consent Mode v2 default (`denied`) + restore `granted` from localStorage, before GA |
| `src/components/CookieConsent.tsx` | New Accept/Reject banner; localStorage + `gtag` consent update |
| `src/styles/cookieConsent.module.css` | New themed styles (CSS Modules, light/dark, responsive) |
| `src/pages/_app.tsx` | Render `<CookieConsent />` (gated on GA env) |

## Design decisions

- **Custom / zero-dependency** over a library or SaaS — smallest footprint, matches the project's lean style, avoids adding a third-party script.
- **Default-denied globally** (not geo-gated) — simplest compliant posture for a static site with no server/geolocation.
- **No new privacy page linked** — avoided creating a dead link; copy states analytics cookies stay off until accepted.

## Testing & validation (headless build of `out/`)

- Fresh visitor: dataLayer order is `consent default(denied) → js → config G-XDP0PEFNH1`; banner shown with Accept/Reject. ✅
- **Accept**: pushes `consent update(granted)`, sets `localStorage['cookie-consent']='granted'`, banner hides. ✅
- **Returning visitor** (granted): banner hidden; dataLayer `default(denied) → update(granted)` on load. ✅
- **Reject**: stays denied (default), choice persisted. ✅
- `yarn tsc --noEmit`, `yarn lint`, `prettier --check .`, `yarn build` all pass; **no console errors/warnings**.

## Accessibility

Banner uses `role="dialog"`, `aria-label`, `aria-live="polite"`; native `<button>` controls with clear labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
