### PR TITLE
feat: basic Google Consent Mode v2 (tag gated behind consent)

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -38,8 +38,12 @@ export default function CookieConsent() {
 
   useEffect(() => {
     try {
-      if (!localStorage.getItem(STORAGE_KEY)) {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
         setVisible(true);
+      } else if (stored === 'granted') {
+        // Re-apply a returning visitor's prior consent (defaults stay denied).
+        updateConsent('granted');
       }
     } catch {
       // localStorage unavailable (e.g. privacy mode); show the banner anyway.

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,4 +1,5 @@
 import styles from '@/styles/cookieConsent.module.css';
+import { GoogleAnalytics } from '@next/third-parties/google';
 import { useCallback, useEffect, useState } from 'react';
 
 const STORAGE_KEY = 'cookie-consent';
@@ -28,13 +29,18 @@ const updateConsent = (choice: ConsentChoice) => {
   globalScope.gtag?.('consent', 'update', CONSENT_STATE[choice]);
 };
 
+interface CookieConsentProps {
+  gaId: string;
+}
+
 /**
- * Minimal cookie consent banner backed by Google Consent Mode v2.
- * Defaults are denied (set in `_document`); this banner records the user's
- * choice in localStorage and updates consent accordingly.
+ * Cookie consent banner using basic Google Consent Mode v2: consent defaults
+ * are denied (set in `_document`) and the Google tag is not loaded until the
+ * user grants consent. On accept, consent is updated and the tag is loaded.
  */
-export default function CookieConsent() {
+export default function CookieConsent({ gaId }: CookieConsentProps) {
   const [visible, setVisible] = useState(false);
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
 
   useEffect(() => {
     try {
@@ -42,8 +48,9 @@ export default function CookieConsent() {
       if (!stored) {
         setVisible(true);
       } else if (stored === 'granted') {
-        // Re-apply a returning visitor's prior consent (defaults stay denied).
+        // Returning visitor who already consented: update and load the tag.
         updateConsent('granted');
+        setAnalyticsEnabled(true);
       }
     } catch {
       // localStorage unavailable (e.g. privacy mode); show the banner anyway.
@@ -58,40 +65,44 @@ export default function CookieConsent() {
       // Ignore storage failures; consent still applies for this session.
     }
     updateConsent(choice);
+    if (choice === 'granted') {
+      setAnalyticsEnabled(true);
+    }
     setVisible(false);
   }, []);
 
-  if (!visible) {
-    return null;
-  }
-
   return (
-    <div
-      className={styles.banner}
-      role="dialog"
-      aria-live="polite"
-      aria-label="Cookie consent"
-    >
-      <p className={styles.text}>
-        This site uses Google Analytics to measure traffic. Analytics cookies
-        stay off until you accept.
-      </p>
-      <div className={styles.actions}>
-        <button
-          type="button"
-          className={`${styles.button} ${styles.reject}`}
-          onClick={() => choose('denied')}
+    <>
+      {analyticsEnabled && <GoogleAnalytics gaId={gaId} />}
+      {visible && (
+        <div
+          className={styles.banner}
+          role="dialog"
+          aria-live="polite"
+          aria-label="Cookie consent"
         >
-          Reject
-        </button>
-        <button
-          type="button"
-          className={`${styles.button} ${styles.accept}`}
-          onClick={() => choose('granted')}
-        >
-          Accept
-        </button>
-      </div>
-    </div>
+          <p className={styles.text}>
+            This site uses Google Analytics to measure traffic. Analytics
+            cookies stay off until you accept.
+          </p>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.reject}`}
+              onClick={() => choose('denied')}
+            >
+              Reject
+            </button>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.accept}`}
+              onClick={() => choose('granted')}
+            >
+              Accept
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import CookieConsent from '@/components/CookieConsent';
-import { GoogleAnalytics } from '@next/third-parties/google';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useEffect } from 'react';
@@ -91,13 +90,12 @@ function App({ Component, pageProps }: AppProps) {
         <title>{title}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID} />
-      )}
       <main>
         <Component {...pageProps} />
       </main>
-      {process.env.NEXT_PUBLIC_GA_TRACKING_ID && <CookieConsent />}
+      {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
+        <CookieConsent gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID} />
+      )}
     </>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -326,7 +326,7 @@ class MyDocument extends Document {
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={{
                 __html:
-                  "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',analytics_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',wait_for_update:500});try{if(localStorage.getItem('cookie-consent')==='granted'){gtag('consent','update',{ad_storage:'granted',analytics_storage:'granted',ad_user_data:'granted',ad_personalization:'granted'});}}catch(e){}",
+                  "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{ad_storage:'denied',ad_user_data:'denied',ad_personalization:'denied',analytics_storage:'denied'});",
               }}
             />
           )}


### PR DESCRIPTION
## Summary

Implements **basic** Google Consent Mode v2 (per [Google's guide](https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic)): consent defaults to `denied`, and the **Google tag is not loaded until the user grants consent**. No tag and no pings are sent before consent.

This supersedes the earlier advanced-mode setup (tag loaded on every page view with cookieless pings) and the `wait_for_update` line that briefly went to `master` — merging this makes the implementation basic mode end to end.

## Implementation (matches the doc's order)

1. **Set consent defaults** (`_document.tsx`, in `<head>`, before anything else): init `dataLayer`, define `gtag`, set `ad_storage`/`ad_user_data`/`ad_personalization`/`analytics_storage` to `denied`. Does **not** load the tag.
2. **Show the consent banner** when no choice is stored (`CookieConsent.tsx`).
3. **Update consent** on the user's choice and persist it in `localStorage`.
4. **Load the Google tag only after consent is granted** — `GoogleAnalytics` renders only when consent is `granted` (on Accept, and on mount for returning visitors who previously accepted).

`_app.tsx` no longer renders `GoogleAnalytics` unconditionally; it passes `gaId` to `CookieConsent`, which owns consent-gated tag loading. No duplicate `dataLayer`/`gtag` initialization.

## Behavior (verified in a headless build)

| Scenario | Result |
| --- | --- |
| First visit (no choice) | **No** `gtag/js` request, no `_next-ga` tag; dataLayer = `consent default(denied)` only; banner shown ✅ |
| Accept | tag loads (`gtag/js?id=G-XDP0PEFNH1`); order `default(denied) → update(granted) → js → config`; banner hides; `granted` stored ✅ |
| Returning (granted) | tag loads on mount; banner hidden ✅ |
| Reject / no choice | tag never loads ✅ |

`tsc`, `lint`, `prettier --check .`, `build` all pass; **no console errors**.

## Trade-off

Basic mode means **no data at all from visitors who don't accept** (no cookieless modeling pings, unlike advanced mode). That's the simplest, most privacy-preserving option for a personal site and what the linked guide describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
