### PR TITLE
docs: refresh project docs for static export and discovery metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ public/          # Static assets served at the root
 | `yarn install`  | Install dependencies                      |
 | `yarn dev`      | Start local development server            |
 | `yarn build`    | Generate static production build (`out/`) |
-| `yarn start`    | Serve the production build locally        |
+| `yarn start`    | Run the production Next.js server locally |
 | `yarn lint`     | Run ESLint                                |
 | `yarn lint:fix` | Run ESLint and auto-fix issues            |
 
@@ -115,6 +115,8 @@ public/          # Static assets served at the root
 > agent/discovery surface is the static files under `public/` plus the `<link>`
 > tags in `src/pages/_document.tsx`; `Accept: text/markdown` negotiation is not
 > active, so fetch `/index.md` directly.
+>
+> The canonical deployment artifact is the generated `out/` directory.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ nvm use          # Must run first — loads Node 24.x from .nvmrc
 yarn install     # Install dependencies
 yarn dev         # Development server (sets NODE_TLS_REJECT_UNAUTHORIZED=0)
 yarn build       # Static export to out/
-yarn start       # Serve the production build locally
+yarn start       # Run the production Next.js server locally
 yarn lint        # ESLint check (run before completing any task)
 yarn lint:fix    # ESLint auto-fix
 ```
@@ -19,6 +19,7 @@ yarn lint:fix    # ESLint auto-fix
 - `output: 'export'` in `next.config.mjs` must stay — site is statically exported to GitHub Pages.
 - No SSR-only or runtime server dependencies allowed.
 - `trailingSlash: true` and `images.unoptimized: true` must not be removed.
+- The canonical deployment artifact is the generated `out/` directory.
 
 ## Path Aliases (tsconfig.json)
 
@@ -35,7 +36,7 @@ Always use aliases — never relative paths.
 
 ## Data Flow
 
-```
+```text
 getStaticProps (build time)
   → fetchData (src/shared/utils/fetch.ts)
   → normalizeGitHub / normalizeMedium (src/shared/utils/)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,6 +8,8 @@ Architecture decisions and rationale for rodcast.github.io.
 
 **Rationale:** The site is a personal portfolio that displays GitHub repositories and Medium articles. All data is public and is refreshed on each deploy. Static export eliminates server infrastructure, reduces cost to zero, and makes the site resilient — there is no runtime to fail.
 
+The deployable artifact is the generated `out/` directory. Any local verification of the exported site should serve that directory as static files.
+
 ## Data Fetching: Build-Time Only
 
 **Decision:** All external API calls happen in `getStaticProps`, not in the browser.
@@ -18,7 +20,7 @@ A 5-second timeout in `fetchData` prevents build hangs. If either API call fails
 
 ## Component Structure
 
-```
+```text
 Page (index.tsx)
 ├── Header         — name, title
 ├── Toggle         — light/dark mode
@@ -29,7 +31,7 @@ Page (index.tsx)
 └── Footer
 
 App (_app.tsx)
-└── Registers WebMCP tools on compatible runtimes
+└── Registers WebMCP tools through `navigator.modelContext` and `document.modelContext`, retrying briefly while those APIs initialize
 ```
 
 `Article` is loaded with `next/dynamic` to defer its JS bundle — it is the heaviest component and not needed for the initial paint.
@@ -42,24 +44,9 @@ App (_app.tsx)
 
 ## Discovery and Agent Metadata (`public/.well-known/`)
 
-The site exposes a set of machine-readable discovery documents:
+The site exposes static discovery metadata under `public/.well-known/`. The main entry points are the API catalog, MCP metadata, agent card, and agent skills index; related OAuth/OIDC, JWKS, AI plugin, HTTP Message Signatures, and security documents live alongside them.
 
-| File                                | Purpose                                     |
-| ----------------------------------- | ------------------------------------------- |
-| `api-catalog`                       | API catalog for agent/client discovery      |
-| `ai-plugin.json`                    | AI plugin metadata and compatibility        |
-| `agent-card.json`                   | Agent identity card                         |
-| `agent-skills/`                     | Agent capability index and skill docs       |
-| `http-message-signatures-directory` | HTTP Message Signatures discovery directory |
-| `mcp.json`                          | MCP endpoint discovery entry point          |
-| `mcp/`                              | Model Context Protocol server metadata      |
-| `oauth-protected-resource`          | OAuth protected resource metadata           |
-| `oauth-authorization-server`        | OAuth 2.0 authorization server metadata     |
-| `openid-configuration`              | OpenID Connect configuration                |
-| `jwks.json`                         | JSON Web Key Set                            |
-| `security.txt`                      | Security disclosure and contact policy      |
-
-These are static JSON/text files committed to `public/`. They require no server. When updating any `agent-skills/*.md`, regenerate the `sha256` in `agent-skills/index.json`.
+These are committed static JSON/text files under `public/`. They require no server. When updating any `agent-skills/*.md`, regenerate the `sha256` in `agent-skills/index.json`.
 
 **Host limitation:** discovery here relies on static files and the `<link>` tags in `_document.tsx`. The HTTP-header layer (`Link`, `Vary`, `Cache-Control`, and `Accept: text/markdown` negotiation defined in `vercel.json` and `public/_headers`) is **not honored by GitHub Pages** — it applies only if the site is served from Vercel/Cloudflare Pages/Netlify. On GitHub Pages, fetch markdown directly at `/index.md`.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn dev
 
 - `yarn dev`: Start the development server (sets `NODE_TLS_REJECT_UNAUTHORIZED=0`).
 - `yarn build`: Build the statically exported site.
-- `yarn start`: Serve the production build locally.
+- `yarn start`: Run the production Next.js server locally.
 - `yarn lint`: Run ESLint checks.
 - `yarn lint:fix`: Run ESLint and auto-fix issues.
 
@@ -49,9 +49,10 @@ yarn dev
 ## Build and Deployment
 
 - Static export via Next.js (`output: 'export'`).
-- Build artifacts are generated in `out/`.
+- The canonical deployment artifact is the static `out/` directory.
 - Deployment runs through GitHub Actions workflow `.github/workflows/nextjs.yml`.
 - Production deploys are triggered by pushes to `master` (and manual workflow dispatch).
+- When validating the exported site locally, serve `out/` with a static file server.
 
 ## Project Conventions
 
@@ -64,11 +65,4 @@ yarn dev
 
 - API overview: `public/docs/api.md`
 - OpenAPI contract: `public/docs/api/openapi.json`
-- API catalog: `public/.well-known/api-catalog`
-- Agent card: `public/.well-known/agent-card.json`
-- MCP discovery: `public/.well-known/mcp.json`
-- MCP server card: `public/.well-known/mcp/server-card.json`
-- OpenID configuration: `public/.well-known/openid-configuration`
-- OAuth authorization server metadata: `public/.well-known/oauth-authorization-server`
-- OAuth protected resource metadata: `public/.well-known/oauth-protected-resource`
-- Agent skills index: `public/.well-known/agent-skills/index.json`
+- Static discovery metadata lives under `public/.well-known/`, including the API catalog, MCP metadata, OAuth/OIDC metadata, agent card, and agent skills index.


### PR DESCRIPTION
## Summary
- update the project docs to reflect the current static-export deployment model and the canonical `out/` artifact
- clarify that `yarn start` runs the production Next.js server locally instead of serving the exported static build
- reduce duplicated discovery metadata inventory while preserving the important entry points and hosting caveats

## Context
The documentation had minor drift from the current implementation:
- the site is deployed as a static export for GitHub Pages, so the deployable artifact is `out/`
- local production-server behavior through `yarn start` is not the same as validating the exported static build
- discovery metadata is exposed through static files under `public/.well-known/` and linked from `_document.tsx`, but some docs repeated a long file-by-file list without adding much operational value

## Decisions
- keep the changes minimal and documentation-only
- preserve useful implementation details already confirmed by the codebase
- replace overly detailed duplicated discovery-file lists with a concise description of the main entry points
- add only the most relevant deployment clarification: use a static file server when validating the exported `out/` directory

## Changes
- update top-level project guidance in `README.md`
- tighten architecture and discovery notes in `DESIGN.md`
- align agent-facing repo guidance in `AGENTS.md`
- align the Claude quick-reference in `CLAUDE.md`
- fix markdown fenced-code lint issues in the touched docs

## Impact
- reduces ambiguity around local validation versus static deployment
- keeps contributor and agent instructions aligned with the current Next.js export setup
- preserves the documented GitHub Pages hosting caveat without expanding scope

## Testing
- [x] reviewed the current implementation in `next.config.mjs`, `src/pages/_app.tsx`, `src/pages/_document.tsx`, `src/pages/index.tsx`, and `src/shared/utils/fetch.ts`
- [x] verified the discovery surface under `public/.well-known/`
- [x] ran `yarn lint`

## Validation
- `yarn lint` passed locally after the documentation updates
- markdown fenced code blocks in the touched docs were corrected and rechecked

## Notes
This PR intentionally excludes unrelated local changes still present in the working tree:
- `src/components/CookieConsent.tsx`
- `src/pages/_app.tsx`
