### PR TITLE
fix: replace personal email contact with safer GitHub channels

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in this project or on
 <https://rodrigocastilho.com/>, please report it privately.
 
-- **Email:** rodcast@gmail.com
+- **Report privately:** [open a GitHub security advisory](https://github.com/rodcast/rodcast.github.io/security/advisories/new)
 - **Languages:** English, Portuguese
 
 Please include enough detail to reproduce the issue (affected URL or file,

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -12,6 +12,5 @@
     "url": "https://rodrigocastilho.com/docs/api/openapi.json"
   },
   "logo_url": "https://rodrigocastilho.com/rodrigo-castilho-rodcast_card.jpg",
-  "contact_email": "rodcast@gmail.com",
   "legal_info_url": "https://rodrigocastilho.com/"
 }

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:rodcast@gmail.com
+Contact: https://github.com/rodcast/rodcast.github.io/security/advisories/new
 Expires: 2026-10-08T00:00:00.000Z
 Preferred-Languages: en, pt
 Canonical: https://rodrigocastilho.com/.well-known/security.txt

--- a/public/auth.md
+++ b/public/auth.md
@@ -210,4 +210,4 @@ Two independent layers:
 
 ## Contact
 
-Integration questions: <mailto:rodcast@gmail.com>
+Integration questions: open an issue at <https://github.com/rodcast/rodcast.github.io/issues>


### PR DESCRIPTION
## Summary
- Remove the `rodcast@gmail.com` address from the public discovery surface so it is no longer exposed in source or fetchable metadata.
- Route contact through GitHub instead, consistent with the existing social links — no new dependencies.

## Changes
- **`.well-known/security.txt`** — `Contact:` now points to GitHub private security advisories (RFC 9116 permits a URL).
- **`SECURITY.md`** — replace the email bullet with a link to open a GitHub private security advisory.
- **`auth.md`** — integration questions now route to GitHub issues.
- **`.well-known/ai-plugin.json`** — drop the optional `contact_email` field; `legal_info_url` (the homepage, which surfaces GitHub/LinkedIn) remains the contact path.

The email never appeared in the rendered UI — the site already links GitHub, LinkedIn, Twitter, and Medium. The role-based `security@rodrigocastilho.com` addresses in `agent/identity/*` are left untouched (separate, out of scope).

## Test plan
- [x] No `rodcast@gmail.com` remains anywhere in the repo
- [x] `ai-plugin.json` is valid JSON
- [x] `yarn lint` and Prettier pass
- [ ] Enable GitHub private vulnerability reporting (Settings → Security) so the advisory link is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)