### PR TITLE
fix: correctness, a11y, and SEO fixes from project review

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import styles from '@/styles/header.module.css';
 /** Navigation component */
 function Navigation() {
   return (
-    <nav className={styles.nav} role="navigation" aria-label="Main navigation">
+    <nav className={styles.nav} aria-label="Main navigation">
       <ul className={styles.navList}>
         <li>
           <a href="#about" className={styles.navLink}>
@@ -28,7 +28,7 @@ function Navigation() {
 /** Site header */
 export default function Header() {
   return (
-    <header className={styles.content} role="banner">
+    <header className={styles.content}>
       <h1 className={styles.logo}>
         <span>Rodrigo Castilho</span>
         RODCAST

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import SocialLinks from './SocialLinks';
 /** Profile sidebar */
 export default function Sidebar() {
   return (
-    <aside className={styles.content} role="complementary" id="about">
+    <aside className={styles.content} id="about">
       <Image
         src="/rodrigo-castilho-rodcast_photo.jpg"
         width={125}
@@ -20,10 +20,10 @@ export default function Sidebar() {
       <h2 className={styles.name} itemProp="name">
         Rodrigo Castilho
       </h2>
-      <h3 className={styles.description} itemProp="description">
+      <p className={styles.description} itemProp="description">
         Staff Frontend Engineer and ex-@Yahoo in a serious relationship with
         programming languages and the gym.
-      </h3>
+      </p>
       <SocialLinks />
     </aside>
   );

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -13,15 +13,14 @@ export default function Toggle() {
   const [checked, setChecked] = useState<boolean>(false);
 
   const checkTheme = useCallback((): void => {
-    const theme = localStorage.getItem('data-theme');
+    // Source of truth: the stored preference, else whatever the pre-paint
+    // script in _document already applied (which honors prefers-color-scheme).
+    const stored = localStorage.getItem('data-theme');
+    const theme = stored ?? document.documentElement.dataset.theme ?? 'light';
 
-    if (theme === 'dark') {
-      document.documentElement.setAttribute('data-theme', 'dark');
-      setChecked(true);
-    } else if (theme === 'light') {
-      document.documentElement.setAttribute('data-theme', 'light');
-      setChecked(false);
-    }
+    document.documentElement.setAttribute('data-theme', theme);
+    const isDark = theme === 'dark';
+    setChecked(isDark);
   }, []);
 
   const toggleTheme = useCallback(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -92,9 +92,7 @@ function App({ Component, pageProps }: AppProps) {
         <title>{title}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <main>
-        <Component {...pageProps} />
-      </main>
+      <Component {...pageProps} />
       {NEXT_PUBLIC_GA_TRACKING_ID && (
         <>
           <CookieConsent />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -23,11 +23,14 @@ function RobotsMeta({ robots }: RobotsMetaProps) {
     <>
       <meta
         name="robots"
-        content={`${robots.index ? 'index' : 'noindex'}, ${
-          robots.follow ? 'follow' : 'nofollow'
-        }, ${robots.nocache ? 'nocache' : ''}, ${
-          robots.noarchive ? 'noarchive' : ''
-        }`}
+        content={[
+          robots.index ? 'index' : 'noindex',
+          robots.follow ? 'follow' : 'nofollow',
+          robots.nocache ? 'nocache' : '',
+          robots.noarchive ? 'noarchive' : '',
+        ]
+          .filter(Boolean)
+          .join(', ')}
       />
       {robots.googleBot && (
         <>
@@ -103,8 +106,8 @@ const metadata = {
   robots: {
     index: true,
     follow: true,
-    nocache: true,
-    noarchive: true,
+    nocache: false,
+    noarchive: false,
     googleBot: {
       index: true,
       follow: true,
@@ -157,6 +160,9 @@ function OpenGraphMeta({ openGraph, twitter }: OpenGraphMetaProps) {
     </>
   );
 }
+
+// Generated at build time so it reflects the latest deploy, not a stale literal.
+const buildDate = new Date().toISOString().slice(0, 10);
 
 // JSON-LD structured data for SEO
 const structuredData = {
@@ -216,11 +222,6 @@ const structuredData = {
       description: metadata.description,
       publisher: { '@id': 'https://rodrigocastilho.com/#person' },
       inLanguage: 'en-US',
-      potentialAction: {
-        '@type': 'SearchAction',
-        target: 'https://rodrigocastilho.com/?s={search_term_string}',
-        'query-input': 'required name=search_term_string',
-      },
     },
     {
       '@type': 'WebPage',
@@ -232,7 +233,7 @@ const structuredData = {
       about: { '@id': 'https://rodrigocastilho.com/#person' },
       primaryImageOfPage: { '@id': 'https://rodrigocastilho.com/#image' },
       datePublished: '2023-01-01',
-      dateModified: '2025-10-23',
+      dateModified: buildDate,
       inLanguage: 'en-US',
     },
     {
@@ -262,6 +263,17 @@ class MyDocument extends Document {
       >
         <Head>
           <meta charSet="utf-8" />
+
+          {/* Apply the stored or system theme before paint to avoid a flash of
+              the wrong theme. Runs first so the toggle can sync to it later. */}
+          <script
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html:
+                "try{var t=localStorage.getItem('data-theme')||(window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.dataset.theme=t;document.documentElement.style.colorScheme=t;}catch(e){}",
+            }}
+          />
+
           <meta name="theme-color" content="#1c1c1c" />
           <meta
             name="theme-color"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,25 +16,39 @@ const Article = dynamic(() => import('@/components/Article'));
 
 /** Fetch data at build time */
 export async function getStaticProps() {
-  try {
-    const [dataGitHub, dataMedium] = await Promise.all([
-      fetchData(GITHUB_API),
-      fetchData(MEDIUM_API),
-    ]);
+  // Fetch sources independently so one failure cannot blank the other.
+  const [githubResult, mediumResult] = await Promise.allSettled([
+    fetchData(GITHUB_API),
+    fetchData(MEDIUM_API),
+  ]);
 
-    return {
-      props: {
-        dataGitHub: normalizeGitHub(dataGitHub),
-        dataMedium: normalizeMedium(dataMedium?.items),
-      },
-    };
-  } catch (error) {
+  if (githubResult.status === 'rejected') {
     // eslint-disable-next-line no-console
-    console.error('Error fetching data at build time:', error);
-    return {
-      props: { dataGitHub: [], dataMedium: [] },
-    };
+    console.error(
+      'Error fetching GitHub data at build time:',
+      githubResult.reason
+    );
   }
+  if (mediumResult.status === 'rejected') {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Error fetching Medium data at build time:',
+      mediumResult.reason
+    );
+  }
+
+  return {
+    props: {
+      dataGitHub:
+        githubResult.status === 'fulfilled'
+          ? normalizeGitHub(githubResult.value)
+          : [],
+      dataMedium:
+        mediumResult.status === 'fulfilled'
+          ? normalizeMedium(mediumResult.value?.items)
+          : [],
+    },
+  };
 }
 
 interface PageProps {

--- a/src/shared/utils/fetch.ts
+++ b/src/shared/utils/fetch.ts
@@ -1,12 +1,10 @@
 /** Fetch data from URL */
 export const fetchData = async (url: string, options?: RequestInit) => {
   const controller = new AbortController();
-  const signal = controller.signal;
-
-  setTimeout(() => controller.abort(), 5000);
+  const timeout = setTimeout(() => controller.abort(), 5000);
 
   const defaultOptions: RequestInit = {
-    signal,
+    signal: controller.signal,
     headers: {
       Accept: 'application/json',
       'User-Agent': 'rodcast.github.io/1.0',
@@ -33,5 +31,7 @@ export const fetchData = async (url: string, options?: RequestInit) => {
     throw new Error('Unknown error occurred while fetching data', {
       cause: error,
     });
+  } finally {
+    clearTimeout(timeout);
   }
 };


### PR DESCRIPTION
## Summary
Applies the safe, dependency-free fixes surfaced by an external project review, each verified against a production build. No behavior regressions — `lint`, `tsc --noEmit`, and `next build` all pass; the exported HTML was inspected to confirm each fix.

## Changes
- **Resilient data fetching** (`index.tsx`): use `Promise.allSettled` so a Medium outage can no longer blank GitHub content (and vice versa).
- **Timer leak** (`fetch.ts`): clear the 5s abort timeout in `finally` — it was created but never cleared.
- **Single `main` landmark** (`_app.tsx`): remove the wrapper `<main>` that nested `Article`'s `<main>` and enclosed `header`/`footer`. `Article` is now the sole `main`.
- **Theme flash** (`_document.tsx` + `Toggle.tsx`): apply the stored/system theme before paint (honors `prefers-color-scheme`); the toggle now syncs to the actually-applied theme.
- **Structured data** (`_document.tsx`): remove the invalid `SearchAction` (no search exists); generate `dateModified` at build time instead of a stale literal; stop emitting `nocache`/`noarchive` so the portfolio can be cached/archived.
- **Semantics** (`Sidebar.tsx`, `Header.tsx`): tagline `<h3>`→`<p>`; drop redundant implicit ARIA roles (`banner`, `navigation`, `complementary`).

## Verification (exported `out/index.html`)
- [x] `<main>` count: 1 (was 2 nested)
- [x] `robots` meta: `index, follow`
- [x] no `SearchAction` in JSON-LD
- [x] theme pre-paint script present
- [x] `dateModified` = build date
- [x] `yarn lint`, `tsc --noEmit`, `next build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)