### PR TITLE
docs: add git workflow rule and dedupe agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,12 +160,20 @@ Follow these rules when making any change to this codebase.
 - Keep accessibility intact: use semantic HTML, labels, and readable fallback messages.
 - Keep SEO metadata and JSON-LD structured data coherent when editing profile content.
 - Run `yarn lint` and resolve all errors before completing a task.
+- Always work on a separate branch and open a pull request for review (see Git Workflow below).
 
 ### Do Not
 
 - Introduce broad refactors or unsolicited "improvements" beyond the task scope.
 - Add SSR-only or runtime server dependencies — the site must remain statically exportable.
 - Break the `next.config.mjs` static export settings (see Critical Constraints below).
+- Commit or push directly to `master`.
+
+### Git Workflow
+
+- **Never commit or push directly to `master`.**
+- Always create a separate branch for your changes and open a pull request.
+- `master` is the deployment branch — a push to it triggers the GitHub Pages build (`.github/workflows/nextjs.yml`). All changes must land via reviewed PRs.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,12 +173,11 @@ Follow these rules when making any change to this codebase.
 
 Before considering any task done, run the full check and resolve all errors — don't rely on "looks done":
 
-```bash
-nvm use                                  # required: husky/build enforce Node 24.x (see .nvmrc)
-yarn lint && yarn typecheck && yarn build
-```
+    nvm use                                  # required: project uses Node 24.x (see .nvmrc)
+    yarn lint && yarn prettier --check . && yarn typecheck && yarn build
 
 - `yarn lint` — ESLint (also enforced by the Husky pre-commit hook).
+- `yarn prettier --check .` — Prettier formatting check (also enforced by the Husky pre-commit hook and CI).
 - `yarn typecheck` — `tsc --noEmit`; must pass with no errors (strict mode).
 - `yarn build` — must produce a successful static export to `out/`; a build failure means the change is not shippable.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Follow these rules when making any change to this codebase.
 - Extend existing shared utilities and components rather than duplicating logic.
 - Keep accessibility intact: use semantic HTML, labels, and readable fallback messages.
 - Keep SEO metadata and JSON-LD structured data coherent when editing profile content.
-- Run `yarn lint` and resolve all errors before completing a task.
+- Verify every change before completing a task (see Verification below).
 - Always work on a separate branch and open a pull request for review (see Git Workflow below).
 
 ### Do Not
@@ -169,11 +169,27 @@ Follow these rules when making any change to this codebase.
 - Break the `next.config.mjs` static export settings (see Critical Constraints below).
 - Commit or push directly to `master`.
 
+### Verification
+
+Before considering any task done, run the full check and resolve all errors — don't rely on "looks done":
+
+```bash
+nvm use                                  # required: husky/build enforce Node 24.x (see .nvmrc)
+yarn lint && yarn typecheck && yarn build
+```
+
+- `yarn lint` — ESLint (also enforced by the Husky pre-commit hook).
+- `yarn typecheck` — `tsc --noEmit`; must pass with no errors (strict mode).
+- `yarn build` — must produce a successful static export to `out/`; a build failure means the change is not shippable.
+
+Show the command output as evidence rather than asserting success.
+
 ### Git Workflow
 
 - **Never commit or push directly to `master`.**
 - Always create a separate branch for your changes and open a pull request.
 - `master` is the deployment branch — a push to it triggers the GitHub Pages build (`.github/workflows/nextjs.yml`). All changes must land via reviewed PRs.
+- Delegate simple, mechanical Git tasks — creating branches, commits, pushes, and pull requests — to a low-cost agent/model (e.g. Haiku) to save cost. These steps don't require deep reasoning, but the rule above still holds: the low-cost agent must branch + open a PR and **never** commit or push directly to `master`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,15 @@ Quick reference for Claude AI. The full project guide (commands, constraints, co
 
 @AGENTS.md
 
+## Delegation & Model Policy
+
+- **Before delegating, verify whether an agent is necessary.** Handle simple and focused tasks directly.
+- Use agents only when they provide clear value — multi-file investigation, isolated research, or parallel work.
+- **Always use the lowest-cost model below Opus that can complete the task reliably.** Do not default to Opus or escalate to it without clear justification.
+- Use Opus only when the task genuinely requires advanced reasoning, complex implementation, debugging, architecture decisions, or high-risk review.
+- Use a low-cost model for simple Git workflow tasks (branches, commits, pushes, pull requests — see `AGENTS.md` → Git Workflow).
+- Keep delegated tasks narrowly scoped, and review the agent's output before applying it.
+
 ## Claude-Specific Notes
 
 - `yarn dev` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` (local-only TLS bypass for development).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,13 @@
 # CLAUDE.md
 
-Quick reference for Claude AI when working on this codebase. See `AGENTS.md` for the full project guide.
+Quick reference for Claude AI. The full project guide (commands, constraints, conventions, Git workflow) is imported below — this file only adds Claude-specific quick-reference details not already covered there.
 
-## Essential Commands
+@AGENTS.md
 
-```bash
-nvm use          # Must run first — loads Node 24.x from .nvmrc
-yarn install     # Install dependencies
-yarn dev         # Development server (sets NODE_TLS_REJECT_UNAUTHORIZED=0)
-yarn build       # Static export to out/
-yarn start       # Run the production Next.js server locally
-yarn lint        # ESLint check (run before completing any task)
-yarn lint:fix    # ESLint auto-fix
-```
+## Claude-Specific Notes
 
-## Critical Constraints
-
-- `output: 'export'` in `next.config.mjs` must stay — site is statically exported to GitHub Pages.
-- No SSR-only or runtime server dependencies allowed.
-- `trailingSlash: true` and `images.unoptimized: true` must not be removed.
-- The canonical deployment artifact is the generated `out/` directory.
+- `yarn dev` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` (local-only TLS bypass for development).
+- CSS Modules for all component styles; globals only in `src/styles/globals.css`.
 
 ## Path Aliases (tsconfig.json)
 
@@ -42,12 +30,3 @@ getStaticProps (build time)
   → normalizeGitHub / normalizeMedium (src/shared/utils/)
   → Page props → Article component
 ```
-
-## Key Conventions
-
-- Normalize all external API data before passing to components.
-- When changing an API contract, update both the interface in `src/shared/interfaces/` and its normalizer.
-- When editing `public/.well-known/agent-skills/*.md`, update the matching `sha256` in `public/.well-known/agent-skills/index.json`.
-- Keep discovery metadata internally consistent across `api-catalog`, OAuth/OIDC metadata, MCP metadata, and agent capability files.
-- CSS Modules for all component styles; globals only in `src/styles/globals.css`.
-- Pre-commit hook runs lint automatically (Husky).


### PR DESCRIPTION
## Summary

- Add a **Git Workflow** rule to `AGENTS.md`: never commit or push directly to `master` — always use a separate branch and open a PR (`master` is the GitHub Pages deploy branch). Also reflected in the Do / Do Not lists.
- Make `CLAUDE.md` import `AGENTS.md` via `@AGENTS.md` so the full project guide is a single source of truth.
- Remove duplicated content from `CLAUDE.md` (Essential Commands, Critical Constraints, and the redundant Key Conventions) now inherited through the import. Kept only Claude-specific extras: the `yarn dev` TLS note, CSS Modules rule, path-alias table, and data-flow diagram.

## Notes

No code or build-config changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)