### PR TITLE
chore: apply minor review cleanups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,10 @@ Follow these rules when making any change to this codebase.
 
 Before considering any task done, run the full check and resolve all errors — don't rely on "looks done":
 
-    nvm use                                  # required: project uses Node 24.x (see .nvmrc)
-    yarn lint && yarn prettier --check . && yarn typecheck && yarn build
+```bash
+nvm use                                  # required: project uses Node 24.x (see .nvmrc)
+yarn lint && yarn prettier --check . && yarn typecheck && yarn build
+```
 
 - `yarn lint` — ESLint (also enforced by the Husky pre-commit hook).
 - `yarn prettier --check .` — Prettier formatting check (also enforced by the Husky pre-commit hook and CI).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,9 +38,9 @@ App (_app.tsx)
 
 ## Styling: CSS Modules
 
-**Decision:** One `.module.css` file per component; global styles only for resets and CSS variables.
+**Decision:** One `.module.css` file per component; global styles only for resets, CSS variables, and a minimal set of accessibility utilities (e.g. `.sr-only`).
 
-**Rationale:** Scoped class names prevent collisions without a runtime CSS-in-JS library. No build-time overhead beyond what Next.js already does.
+**Rationale:** Scoped class names prevent collisions without a runtime CSS-in-JS library. No build-time overhead beyond what Next.js already does. A small number of accessibility utilities like `.sr-only` are intentionally global so they can be reused across components without duplication.
 
 ## Discovery and Agent Metadata (`public/.well-known/`)
 

--- a/src/shared/interfaces/github.ts
+++ b/src/shared/interfaces/github.ts
@@ -5,7 +5,6 @@ export interface IGitHub {
   description: string;
   updated_at: string;
   is_private?: boolean;
-  private?: boolean;
   fork?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Minor cleanups surfaced by an audit of the codebase against AGENTS.md / DESIGN.md. No behavior change.

- Remove the dead optional `private?` field from the `IGitHub` interface — the normalizer only ever sets `is_private`; the raw `private` field stays on `IGitHubRepo`.
- Document `.sr-only` as an allowed global accessibility utility in `DESIGN.md` (resolves a doc/code mismatch; sr-only is canonically a global utility).
- Wrap the `AGENTS.md` verification commands in a fenced code block.

## Verification

`yarn lint && yarn prettier --check . && yarn typecheck && yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)