### PR TITLE
revert: remove webpack-based CSS Module class-name override

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -82,9 +82,7 @@ jobs:
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
       - name: Build with Next.js
-        # Use the package.json "build" script so the --webpack flag (required
-        # for the CSS Modules class-name override in next.config.mjs) is applied.
-        run: ${{ steps.detect-package-manager.outputs.manager }} build
+        run: ${{ steps.detect-package-manager.outputs.runner }} next build
         env:
           # Set this as an Actions *variable* (Settings -> Secrets and
           # variables -> Actions -> Variables). It is a public GA measurement

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,27 +1,4 @@
-import { createHash } from 'node:crypto';
-import { relative, sep } from 'node:path';
-
 const isDev = process.env.NODE_ENV === 'development';
-
-// Generate short, stable CSS Module class names using only a hash.
-// The hash includes the source file path and original local class name,
-// which keeps names deterministic and reduces collision risk across files.
-const cssModuleLocalIdent = (context, _localIdentName, localName) => {
-  const resourcePath = relative(context.rootContext, context.resourcePath)
-    .split(sep)
-    .join('/');
-
-  const hash = createHash('sha256')
-    .update(`${resourcePath}\0${localName}`)
-    .digest('base64')
-    .replace(/[^a-zA-Z0-9]/g, '');
-
-  const firstLetterIndex = hash.search(/[a-zA-Z]/);
-  const start = firstLetterIndex === -1 ? 0 : firstLetterIndex;
-  const ident = hash.slice(start, start + 6).padEnd(6, 'a');
-
-  return /^[a-zA-Z]/.test(ident) ? ident : `a${ident.slice(1)}`;
-};
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -44,32 +21,6 @@ const nextConfig = {
   },
   experimental: {
     inlineCss: true,
-  },
-  // Use compact CSS Module class names in production builds.
-  // We do this by overriding css-loader's local ident generator.
-  // Turbopack does not currently expose this setting, so webpack is used
-  // (via the --webpack flag in package.json) for this customization.
-  // Development keeps Next.js defaults for easier debugging.
-  webpack(config, { dev }) {
-    if (dev) return config;
-
-    const oneOf = config.module.rules.find((rule) =>
-      Array.isArray(rule.oneOf)
-    )?.oneOf;
-
-    oneOf
-      ?.flatMap((rule) => (Array.isArray(rule.use) ? rule.use : []))
-      .forEach((loader) => {
-        if (
-          typeof loader.loader === 'string' &&
-          loader.loader.includes('css-loader') &&
-          loader.options?.modules
-        ) {
-          loader.options.modules.getLocalIdent = cssModuleLocalIdent;
-        }
-      });
-
-    return config;
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "postcss": "8.5.10"
   },
   "scripts": {
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --webpack",
-    "build": "next build --webpack",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## What

Reverts the webpack changes introduced in #898, returning dev and production builds to Next.js's default **Turbopack** bundler.

- **`next.config.mjs`** — removes the `webpack` callback, the `getLocalIdent` helper, and its now-unused `node:crypto` / `node:path` imports.
- **`package.json`** — drops the `--webpack` flag from the `dev` and `build` scripts.
- **`.github/workflows/nextjs.yml`** — build step runs `next build` again (instead of the `build` script).

## Why

Reverting the webpack changes as requested.

## Effect

CSS Module class names revert to Next.js / Turbopack defaults (e.g. `sidebar-module__ENZV2q__description`); the short hash-only names from #898 are no longer produced. Static export (`output: 'export'`), styles, and all other build configuration are unchanged. The unrelated `CLAUDE.md` wording from #898 is left in place.

## Verification

All green on Node 24 (`.nvmrc`):

- `yarn lint`
- `yarn prettier --check .`
- `yarn typecheck`
- `yarn build` (static export to `out/`, Turbopack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)