### PR TITLE
fix: update LinkedIn profile URL to /in/rodcast

### DIFF
--- a/public/index.md
+++ b/public/index.md
@@ -14,7 +14,7 @@ Staff Frontend Engineer and ex-@Yahoo in a serious relationship with programming
 - **Website:** https://rodrigocastilho.com/
 - **GitHub:** https://github.com/rodcast
 - **Twitter:** https://twitter.com/rodcast
-- **LinkedIn:** https://www.linkedin.com/in/rodrigocastilho
+- **LinkedIn:** https://www.linkedin.com/in/rodcast
 - **Medium:** https://medium.com/@rodcast
 
 ## Projects
@@ -50,7 +50,7 @@ Read all articles at [medium.com/@rodcast](https://medium.com/@rodcast).
         "https://github.com/rodcast",
         "https://twitter.com/rodcast",
         "https://medium.com/@rodcast",
-        "https://www.linkedin.com/in/rodrigocastilho"
+        "https://www.linkedin.com/in/rodcast"
       ]
     },
     {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -27,5 +27,5 @@ The site is a statically exported Next.js application. Project and article data 
 
 - [GitHub](https://github.com/rodcast)
 - [Twitter](https://twitter.com/rodcast)
-- [LinkedIn](https://www.linkedin.com/in/rodrigocastilho)
+- [LinkedIn](https://www.linkedin.com/in/rodcast)
 - [Medium](https://medium.com/@rodcast)

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -211,7 +211,7 @@ const structuredData = {
         'https://twitter.com/rodcast',
         'https://github.com/rodcast',
         'https://medium.com/@rodcast',
-        'https://www.linkedin.com/in/rodrigocastilho',
+        'https://www.linkedin.com/in/rodcast',
       ],
     },
     {


### PR DESCRIPTION
## What

Updates the LinkedIn profile link from the old `/in/rodrigocastilho` to the current vanity URL `https://www.linkedin.com/in/rodcast` everywhere it appears.

- **`public/index.md`** — profile links list + JSON-LD `sameAs`
- **`public/llms.txt`** — profile links list
- **`src/pages/_document.tsx`** — JSON-LD `sameAs` in the page's structured data

## Why

The previous URL pointed at an outdated profile slug. This keeps the discovery/SEO surfaces (Markdown profile, llms.txt, and the page's structured data) consistent with the live LinkedIn handle.

## Reviewer notes

- Content/metadata-only change; no logic or build-config changes.
- The three `sameAs`/profile references are now consistent.

## Verification

All green on Node 24 (`.nvmrc`):

- `yarn lint`
- `yarn prettier --check .`
- `yarn typecheck`
- `yarn build` (static export to `out/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)