### PR TITLE
chore: add Claude Code project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // empty' | { read -r f; [ -n \"$f\" ] && yarn --silent prettier --write --ignore-unknown \"$f\" >/dev/null 2>&1; } || true"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path // empty' | { read -r f; case \"$f\" in *.ts|*.tsx) yarn --silent eslint --fix --no-warn-ignored \"$f\" >/dev/null 2>&1 ;; esac; } || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$b\" = \"master\" ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"AGENTS.md forbids direct git commit to master. Create a feature branch and open a PR.\"}}'; fi"
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push*)",
+            "command": "b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ \"$b\" = \"master\" ]; then printf '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"AGENTS.md forbids direct git push to master. Push to a feature branch and open a PR.\"}}'; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # local mcp config
 .mcp.json
+
+# claude code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add a shared `.claude/settings.json` so the whole team gets consistent Claude Code behavior on this repo.
- Keeps personal Claude config (`settings.local.json`) out of version control.

## Changes
- **`.claude/settings.json`** (new): PostToolUse hooks that run Prettier on every written file and ESLint `--fix` on `.ts`/`.tsx`; PreToolUse hooks that deny `git commit`/`git push` directly to `master`, enforcing the AGENTS.md branch-and-PR workflow.
- **`.gitignore`**: ignore `.claude/settings.local.json` (personal permissions / local MCP toggles).

## Test plan
- [ ] Edit a file via Claude Code and confirm Prettier/ESLint run automatically.
- [ ] Attempt `git commit` on `master` and confirm the PreToolUse hook blocks it.
- [ ] Confirm `.claude/settings.local.json` stays untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)