### PR TITLE
chore: add verify-project skill and git-workflow rule

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,7 @@
+# Git Workflow Rule
+
+The canonical Git workflow lives in [`AGENTS.md`](../../AGENTS.md) → **Git Workflow**. This file is a pointer so the rule loads in Claude Code sessions — keep the details in `AGENTS.md`, not here.
+
+**The rule in one line:** never commit or push directly to `master`; create a feature branch and open a pull request for every change.
+
+`master` is the deployment branch — a push triggers the GitHub Pages build (`.github/workflows/nextjs.yml`), so all changes must land via reviewed PRs. This is also enforced mechanically by the `PreToolUse` guards in `.claude/settings.json`, which deny `git commit` and `git push` while on `master`.

--- a/.claude/skills/verify-project/SKILL.md
+++ b/.claude/skills/verify-project/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: verify-project
+description: Run the project's full verification suite (lint, Prettier check, typecheck, static build) and report results. Use before opening a PR, after finishing a change, or whenever the user asks to verify, validate, or check that the project is shippable.
+---
+
+# Verify Project
+
+Run the full quality gate defined in `AGENTS.md` → **Verification** and resolve every error before declaring success. Show the command output as evidence — never assert success without it.
+
+## Steps
+
+1. **Activate the correct Node version.** The project requires Node 24.x (see `.nvmrc`). The pre-commit hook fails on the wrong version, so always start here:
+
+   ```bash
+   nvm use
+   ```
+
+2. **Run the full suite.** Each step must pass with no errors:
+
+   ```bash
+   yarn lint && yarn prettier --check . && yarn typecheck && yarn build
+   ```
+
+   | Command                   | Checks                                                        |
+   | ------------------------- | ------------------------------------------------------------- |
+   | `yarn lint`               | ESLint (also enforced by the Husky pre-commit hook)           |
+   | `yarn prettier --check .` | Prettier formatting (pre-commit hook + CI)                    |
+   | `yarn typecheck`          | `tsc --noEmit`, strict mode — must report zero errors         |
+   | `yarn build`              | Static export to `out/` — a build failure means not shippable |
+
+3. **Report honestly.** If any step fails, show the failing output, fix the cause, and re-run the whole suite. Do not skip a step or call the task done on a partial pass.
+
+## Notes
+
+- Run the steps as a single chained command so a failure short-circuits the rest.
+- This project has no automated test suite; this suite is the enforced baseline quality check.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 Quick reference for Claude AI. The full project guide (commands, constraints, conventions, Git workflow) is imported below — this file only adds Claude-specific quick-reference details not already covered there.
 
 @AGENTS.md
+@.claude/rules/git-workflow.md
 
 ## Delegation & Model Policy
 


### PR DESCRIPTION
## Summary
- Add a `/verify-project` skill so anyone can run the full quality gate in one command.
- Wire the git-workflow rule into Claude Code sessions without duplicating AGENTS.md.

## Changes
- **`.claude/skills/verify-project/SKILL.md`** (new): runs the AGENTS.md verification suite — `nvm use` then `yarn lint && yarn prettier --check . && yarn typecheck && yarn build` — and reports honestly.
- **`.claude/rules/git-workflow.md`** (new): thin pointer to AGENTS.md → Git Workflow (never commit/push to master; branch + PR).
- **`CLAUDE.md`**: add `@.claude/rules/git-workflow.md` import so the rule actually loads.

## Test plan
- [ ] Invoke `/verify-project` and confirm it runs the full suite.
- [ ] Confirm the git-workflow rule loads in a new Claude Code session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)