### PR TITLE
docs: sync verification commands; add Claude Code agent and skills

### DIFF
--- a/.claude/agents/static-export-guardian.md
+++ b/.claude/agents/static-export-guardian.md
@@ -1,0 +1,38 @@
+---
+name: static-export-guardian
+description: Reviews a diff for changes that would break the Next.js static export or the GitHub Pages deployment. Use after implementing a change and before opening a PR, or whenever a change touches next.config.mjs, data fetching, dependencies, or the discovery metadata surface.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Static Export Guardian
+
+This site is statically exported (`next build` → `out/`) and hosted on GitHub Pages. The most catastrophic failure mode is a change that silently breaks static export or the discovery surface. Review the current diff against the Critical Constraints in `AGENTS.md` and report violations.
+
+## What to check
+
+1. **Static-export config is intact** (`next.config.mjs`):
+   - `output: 'export'`, `images.unoptimized: true`, and `trailingSlash: true` must all be present and unchanged.
+
+2. **No SSR-only or runtime-server code:**
+   - No `getServerSideProps`, no API routes (`src/pages/api/*`), no middleware, no `export const dynamic`/`runtime` server directives.
+   - Data must be fetched at build time via `getStaticProps` only.
+
+3. **No server/runtime dependencies added:**
+   - Inspect added `dependencies` in `package.json`. The site must remain statically exportable — flag anything that requires a Node server at request time.
+
+4. **External API data is normalized:**
+   - New GitHub/Medium data must flow through the normalizers in `src/shared/utils/` and a matching interface in `src/shared/interfaces/`. If a contract changed, the interface and normalizer must change together.
+
+5. **Discovery metadata stays consistent:**
+   - Links in `src/pages/_document.tsx` (honored on GitHub Pages) must agree with the `Link` header in `public/_headers` and `vercel.json`.
+   - `.well-known` documents (`api-catalog`, `agent-card.json`, `mcp.json`, `mcp/server-card.json`, OAuth/OIDC metadata, agent-skills index) must remain internally consistent.
+   - Any edited `public/.well-known/agent-skills/*.md` must have a matching refreshed `sha256` in `agent-skills/index.json`.
+
+6. **Accessibility & SEO not regressed:** semantic HTML, labels, readable fallbacks, and coherent JSON-LD when profile content changes.
+
+## How to work
+
+- Run `git diff master...HEAD` (or `git diff` for uncommitted work) to scope the review to changed files.
+- For high-risk changes, run `yarn build` and confirm a clean static export to `out/`.
+- Report findings as a prioritized list: **blocker** (breaks export/deploy) → **warning** (convention/consistency) → **nit**. Cite `file:line`. If nothing is wrong, say so plainly.

--- a/.claude/skills/check-discovery-consistency/SKILL.md
+++ b/.claude/skills/check-discovery-consistency/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: check-discovery-consistency
+description: Audit the agent-discovery surface for internal consistency — .well-known documents, agent-skills sha256 hashes, WebMCP tools, and the discovery links in _document.tsx / _headers / vercel.json. Use after editing any discovery metadata, or when asked to validate the .well-known surface.
+---
+
+# Check Discovery Consistency
+
+This site publishes a rich agent-discovery surface. The files must stay internally consistent — `AGENTS.md` → **Discovery Metadata** treats this as a recurring obligation. This skill is a read-and-verify audit; it reports drift and proposes fixes, it does not blindly rewrite.
+
+## What to verify
+
+1. **agent-skills integrity** (`public/.well-known/agent-skills/`):
+   - For every `*.md`, compute `shasum -a 256 <file>` and compare to the matching `skills[].sha256` in `index.json` (matched by the entry's `url` basename).
+   - Every `index.json` entry must point to a file that exists; every `*.md` should have an entry.
+
+2. **Cross-document coherence** (`public/.well-known/`):
+   - `api-catalog`, `agent-card.json`, `mcp.json`, `mcp/server-card.json`, `ai-plugin.json`, OAuth/OIDC metadata (`openid-configuration`, `oauth-authorization-server`, `oauth-protected-resource`), and `jwks.json` should reference consistent URLs, names, and endpoints (all under the `homepage` origin in `package.json`).
+
+3. **Discovery links agree across surfaces:**
+   - The `<link>` discovery tags in `src/pages/_document.tsx` (the surface honored on GitHub Pages) must match the `Link` header entries in `public/_headers` and `vercel.json`. Note: GitHub Pages ignores `_headers`/`vercel.json`, so `_document.tsx` is authoritative for production.
+
+4. **WebMCP tools:**
+   - Tools registered in `src/shared/utils/webmcpTools.ts` / `src/pages/_app.tsx` should match what `webmcp-tools.md` and `mcp.json` advertise.
+
+## How to work
+
+- Use `shasum -a 256` and `jq` to compare hashes and JSON fields; read the `.md` and `.tsx` sources directly.
+- Report findings as a table: file, expected, actual, fix. Recompute and show the correct `sha256` values for any drifted agent-skills entry.
+- After applying fixes, re-run the hash check to confirm convergence.

--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: new-component
+description: Scaffold a new React component with its paired CSS Module following project conventions (path aliases, strict TypeScript, accessibility baseline). Use when the user asks to create, add, or scaffold a new UI component.
+disable-model-invocation: true
+---
+
+# New Component
+
+Create a component in `src/components/` paired with a CSS Module in `src/styles/`, matching the conventions already used across the codebase. Read an existing component (e.g. `src/components/Footer.tsx`) and its module before writing, so the new one matches local idiom.
+
+## Conventions (non-negotiable)
+
+- **CSS Modules for all component styles** — never inline styles or `globals.css` for component-scoped rules.
+- **Path aliases only** — `@/styles/*`, `@/components/*`, `@/utils/*`, `@/interfaces/*`. Never relative paths.
+- **Strict TypeScript** — type all props via an explicit `interface`; no `any`.
+- **Design tokens** — use the CSS custom properties already in the modules (`var(--space-x-*)`, `var(--text-*)`, `var(--secondary-color)`, …) rather than hardcoded values.
+- **Accessibility** — semantic HTML, `aria-*`/labels where needed, readable fallback text.
+- **Formatting** — 2-space indent, single quotes, semicolons, trailing newline (Prettier enforces this on save).
+
+## Steps
+
+1. Ask for (or infer) the component name in PascalCase, e.g. `ProfileCard`.
+2. Create `src/styles/<camelCase>.module.css` with a `.content` (or appropriate root) class using design tokens.
+3. Create `src/components/<PascalCase>.tsx`:
+
+   ```tsx
+   import styles from '@/styles/<camelCase>.module.css';
+
+   interface <PascalCase>Props {
+     // typed props
+   }
+
+   /** <one-line description> */
+   export default function <PascalCase>({ ... }: <PascalCase>Props) {
+     return <section className={styles.content}>...</section>;
+   }
+   ```
+
+4. Wire it into its parent page/component using the path alias import.
+5. Verify with the `verify-project` skill (lint, Prettier, typecheck, build) before declaring done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,15 +85,16 @@ public/          # Static assets served at the root
 
 ## Common Commands
 
-| Command         | Purpose                                   |
-| --------------- | ----------------------------------------- |
-| `nvm use`       | Load Node version defined in `.nvmrc`     |
-| `yarn install`  | Install dependencies                      |
-| `yarn dev`      | Start local development server            |
-| `yarn build`    | Generate static production build (`out/`) |
-| `yarn start`    | Run the production Next.js server locally |
-| `yarn lint`     | Run ESLint                                |
-| `yarn lint:fix` | Run ESLint and auto-fix issues            |
+| Command          | Purpose                                   |
+| ---------------- | ----------------------------------------- |
+| `nvm use`        | Load Node version defined in `.nvmrc`     |
+| `yarn install`   | Install dependencies                      |
+| `yarn dev`       | Start local development server            |
+| `yarn build`     | Generate static production build (`out/`) |
+| `yarn start`     | Run the production Next.js server locally |
+| `yarn lint`      | Run ESLint                                |
+| `yarn lint:fix`  | Run ESLint and auto-fix issues            |
+| `yarn typecheck` | Type-check with `tsc --noEmit` (strict)   |
 
 > Run `nvm use` before Yarn commands to ensure the exact Node version from `.nvmrc` is active.
 > **Node version:** 24.x (see `.nvmrc`). **Package manager:** Yarn.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ yarn dev
 - `yarn start`: Run the production Next.js server locally.
 - `yarn lint`: Run ESLint checks.
 - `yarn lint:fix`: Run ESLint and auto-fix issues.
+- `yarn typecheck`: Type-check the project with `tsc --noEmit` (strict mode).
 
 ## Environment
 
@@ -43,8 +44,7 @@ yarn dev
 1. Run `nvm use`.
 2. Install dependencies with `yarn install`.
 3. Start local development with `yarn dev`.
-4. Run `yarn lint` before opening a PR.
-5. Validate production output with `yarn build`.
+4. Before opening a PR, run the full verification suite: `yarn lint && yarn prettier --check . && yarn typecheck && yarn build`.
 
 ## Build and Deployment
 


### PR DESCRIPTION
## What

Part of a review of all config/Markdown files for accuracy and consistency.

**Docs sync:**
- **AGENTS.md** — added `yarn typecheck` to the Common Commands table.
- **README.md** — added `yarn typecheck` to the Scripts list, and replaced the lint-only pre-PR step with the full verification gate (`yarn lint && yarn prettier --check . && yarn typecheck && yarn build`) to match the canonical suite in AGENTS.md.

**Track Claude Code config used during the review:**
- `.claude/agents/static-export-guardian.md` — agent that guards the Next.js static export and GitHub Pages deploy.
- `.claude/skills/check-discovery-consistency/SKILL.md` — audits the `.well-known`/agent-skills discovery surface.
- `.claude/skills/new-component/SKILL.md` — scaffolds components per project conventions.

## Why

The `yarn typecheck` script exists in `package.json` and is part of the documented verification suite, but it was missing from the command lists in both docs — an accuracy/synchronization gap. No other inaccuracies were found across `AGENTS.md`, `CLAUDE.md`, `README.md`, `DESIGN.md`, `SECURITY.md`, `llms.txt`, `.github/`, `.claude/`, `public/docs/`, and `public/.well-known/`: versions (Next 16 / React 19 / Node 24), path aliases, agent-skills `sha256` hashes, repo URL, and profile bio text all already matched the code.

The previously untracked `.claude/` agent and skills are now committed so the project's Claude Code setup is versioned alongside the docs they support.

## Reviewer notes

- Docs and Claude Code config only; no source or build behavior affected.
- Verified locally: `yarn lint`, `yarn prettier --check .`, `yarn typecheck`, and `yarn build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)