### PR TITLE
chore: add css-modules-to-tailwind migration skill

### DIFF
--- a/.claude/skills/css-modules-to-tailwind/SKILL.md
+++ b/.claude/skills/css-modules-to-tailwind/SKILL.md
@@ -186,6 +186,16 @@ For each CSS module, smallest first, do this full loop before moving on:
    ```bash
    npx tsc --noEmit && <lint> && <build>
    ```
+   **Delegate a static-export/deploy review before opening the PR.** This
+   migration adds dependencies (`tailwindcss`, `@tailwindcss/postcss`), a
+   `postcss.config.mjs`, and changes the build pipeline — the kind of change that
+   can silently break a static export (`output: 'export'` → `out/`) or the host
+   deploy. If the project ships a build/deploy-guard subagent, hand it the diff.
+   In this repo that's the **`static-export-guardian`** agent (read-only,
+   `sonnet`) — its remit is precisely "after implementing a change and before
+   opening a PR, or whenever a change touches `next.config.mjs`, data fetching,
+   dependencies, or the discovery metadata surface." Run it, resolve anything it
+   flags, then proceed.
 2. **Confirm the migration is complete** — no module files or imports left
    behind:
    ```bash

--- a/.claude/skills/css-modules-to-tailwind/SKILL.md
+++ b/.claude/skills/css-modules-to-tailwind/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: css-modules-to-tailwind
+description: >-
+  Migrate CSS Modules to Tailwind CSS v4 in a Next.js/React/TypeScript project —
+  rewrite every `*.module.css`/`*.module.scss` rule into Tailwind utilities,
+  update all component `className` references (including template literals,
+  clsx/classnames, and composed multi-module class strings), preserve the exact
+  rendered UI and runtime behavior, delete the orphaned module files, and
+  validate with build + typecheck plus a class-by-class audit report. Use this
+  whenever the user wants to convert, migrate, port, or move styles off CSS
+  Modules onto Tailwind (or "tailwindify" / "drop CSS modules" / "replace
+  *.module.css"), set up Tailwind v4 in a project that currently uses CSS
+  Modules, or modernize a component's styling to utility classes — even if they
+  only mention one component or don't say "Tailwind v4" explicitly.
+---
+
+# CSS Modules → Tailwind CSS v4 Migration
+
+## What this skill does and why it's shaped this way
+
+Converting CSS Modules to Tailwind looks like a find-and-replace job but isn't.
+The danger is silent visual regressions: a `max-width` media query that becomes a
+`min-width` utility, a sibling selector that loses its relationship, a CSS
+variable that was being swapped at runtime for theming and gets frozen into a
+static value, or a kept global reset (`* { margin: 0 }`) that sits _outside_
+Tailwind's cascade layers and silently overrides every spacing utility. The
+output compiles and _looks_ done, but the UI shifted.
+
+So the whole approach is built around one idea: **preserve observable behavior
+exactly, prove it component-by-component, and never delete a source of truth
+until its replacement compiles clean.** "Compiles clean" is necessary but not
+sufficient — the build passing tells you nothing about whether pixels moved, so
+the migration isn't done until you've _diffed the rendered output_ against the
+original (Phase 3). Aggressive utility conversion (the goal: no `.module.css`
+files left) is safe only when paired with that discipline.
+
+Work in this order. Each phase exists to shrink the blast radius of a mistake.
+
+## Phase 0 — Discover and plan
+
+Run the discovery script to map the work before touching anything:
+
+```bash
+node <skill-dir>/scripts/discover.mjs
+```
+
+It lists every `*.module.css` / `*.module.scss` file, the components that import
+each, how the import is aliased (`styles`, `icon`, …), and flags files that
+share a module across multiple components (migrate those together). Read its
+output, then read `references/edge-cases.md` so you recognize the hard patterns
+_before_ you hit them.
+
+Establish a baseline so you can prove nothing broke:
+
+```bash
+# Use the project's own verify command if it has one (check package.json / AGENTS.md).
+# Otherwise the generic gate:
+npx tsc --noEmit && <project build command>
+```
+
+**Capture a visual baseline now**, while the original styling is still intact —
+this is the only "before" you'll get to diff against in Phase 3. The simplest,
+git-based option needs no up-front screenshots: just note the pre-migration
+commit (`git rev-parse HEAD`) so Phase 3 can build that ref in a worktree and
+screenshot it. If the original is _not_ in git (uncommitted), screenshot the key
+pages/states now (see Phase 3 for the headless-Chrome recipe) and save them under
+e.g. `/tmp/vrt/old-*.png`. Either way, list the **distinct visual states** worth
+checking — at minimum desktop + mobile widths, plus light/dark theme and any
+toggle/hover/expanded states unique to the components in scope.
+
+Decide an order: **leaf/presentational components first, shared/global last.**
+Migrate the smallest, least-depended-on component first to validate your setup
+before risking a widely-used one.
+
+Present the plan to the user (files, order, anything that can't become a pure
+utility) and confirm before bulk edits — especially before touching global
+styles or theme tokens.
+
+## Phase 1 — Set up Tailwind v4 (only if not already present)
+
+Check first: look for `@import "tailwindcss"` and `tailwindcss` in
+`package.json`. If Tailwind v4 is already wired up, skip to Phase 2. If a v3
+config (`tailwind.config.js` + `content` globs) exists, read
+`references/tailwind-v4-setup.md` → "Upgrading from v3" before changing anything.
+
+Otherwise install and configure v4 following `references/tailwind-v4-setup.md`.
+The short version for Next.js:
+
+1. `npm i -D tailwindcss @tailwindcss/postcss` (or the project's package manager).
+2. Add the PostCSS plugin (`postcss.config.mjs` → `'@tailwindcss/postcss': {}`).
+3. Put `@import "tailwindcss";` at the top of the global stylesheet (e.g.
+   `src/styles/globals.css`) — the one already imported in `_app`.
+
+**Cascade layers — the regression that compiles clean and still breaks the whole
+page.** Tailwind v4 puts every utility inside `@layer utilities`. Per the CSS
+cascade-layers rule, **any unlayered declaration beats any layered one regardless
+of specificity.** So existing global rules left _below_ the `@import` (a
+`* { margin: 0; padding: 0 }` reset, `a { text-decoration: none }`, element
+resets) will silently override `p-8`, `mt-8`, `mx-8`, `underline`, and every
+other utility you write — the build passes, but spacing and decorations collapse
+across the entire site. **Wrap the project's kept base/reset element rules in
+`@layer base`** (the same layer Tailwind's preflight uses) so utilities can win:
+
+```css
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  /* …other element/reset rules… */
+}
+```
+
+Leave `:root`/theme-selector **custom-property** blocks unlayered (they don't
+conflict with utilities), and leave intentional always-win helpers like
+`.sr-only` unlayered on purpose. See `references/tailwind-v4-setup.md` →
+"Cascade layers" and `references/edge-cases.md` → "Cascade layers".
+
+**Theme tokens — the most important decision in this phase.** Read the global
+stylesheet's `:root` custom properties. There are two kinds and they migrate
+differently:
+
+- **Static design tokens** (a spacing scale, fixed brand colors) → move into an
+  `@theme { … }` block so they generate utilities (`--color-brand` → `bg-brand`).
+- **Runtime-swapped variables** (anything overridden under a selector like
+  `html[data-theme='dark']`, `.dark`, or a `prefers-color-scheme` block) →
+  **keep them as plain CSS custom properties.** `@theme` tokens are static; if
+  you bake them in, theme switching silently breaks. Reference them from
+  utilities via arbitrary values, e.g. `bg-[var(--primary-color)]`, or register
+  the variable name in `@theme` while leaving the _overrides_ in normal CSS.
+  Map the project's theming trigger to the right Tailwind variant (a
+  `[data-theme='dark']` attribute needs a custom `@custom-variant`, not the
+  default `dark:`). `references/edge-cases.md` → "Theming" has the recipes.
+
+Verify the build still passes before migrating a single component.
+
+## Phase 2 — Migrate one component at a time
+
+For each CSS module, smallest first, do this full loop before moving on:
+
+1. **Read** the `.module.css` file and _every_ component that imports it.
+2. **Map** each class to utilities using `references/mapping.md`. Preserve exact
+   values — when a value isn't on Tailwind's default scale, use an arbitrary
+   value (`top-[50px]`, `w-[68px]`, `gap-[var(--space-x-2)]`) rather than
+   rounding to the nearest utility. Approximation is how regressions creep in.
+3. **Rewrite the markup.** Replace each `className={styles.foo}` with the mapped
+   utilities. Handle the real-world shapes (see `references/edge-cases.md`):
+   - Template literals combining modules + props:
+     ``className={`${styles.a} ${icon.b}`}`` → merge both classes' utilities.
+   - `clsx` / `classnames` / conditional expressions → keep the conditional
+     structure, swap module references for utility strings.
+   - A class used by several elements → expand it at each site (or, if it's
+     genuinely repeated and complex, see the `@apply`/`@utility` escape hatch in
+     `references/edge-cases.md` — use sparingly; inline utilities are the goal).
+4. **Translate the hard selectors** — don't drop them:
+   - `:hover` `:focus` `:active` `:disabled` → `hover:` `focus:` etc.
+   - `:before` / `:after` → `before:` / `after:` (content via `content-['…']`).
+   - Sibling/checked patterns (`input:checked + .slider`) → the `peer` pattern
+     (`peer` on the input, `peer-checked:` on the sibling).
+   - Child/descendant (`.logo > span`) → arbitrary variants (`[&>span]:hidden`)
+     or move the class onto the child element directly.
+   - `@media (max-width: …)` → **`max-*` variants** (`max-md:flex-col`).
+     Tailwind is mobile-first; a plain `md:` would invert the breakpoint. This
+     is the single most common silent regression — double-check every media
+     query's direction.
+   - `@keyframes` → define the animation in `@theme` (`--animate-…`) per
+     `references/edge-cases.md`.
+5. **Verify incrementally:** run typecheck (and a build if quick) after each
+   component. Catching a break here localizes it to the file you just touched.
+6. **Record** the mapping in the audit report (Phase 3) as you go — old class →
+   new utilities, plus any rule that couldn't become a pure utility and where it
+   lives now.
+7. **Delete** the now-orphaned `.module.css` file and remove its import — but
+   only once the importing component(s) compile with no remaining references to
+   it. Confirm with a quick grep that no `styles.` (or the alias) usage remains.
+
+## Phase 3 — Validate and report
+
+1. **Full verify gate** — run the project's complete check. Resolve every error;
+   "looks done" is not done. Generic fallback:
+   ```bash
+   npx tsc --noEmit && <lint> && <build>
+   ```
+2. **Confirm the migration is complete** — no module files or imports left
+   behind:
+   ```bash
+   node <skill-dir>/scripts/discover.mjs --check
+   ```
+   It exits non-zero and lists offenders if any `*.module.{css,scss}` file or
+   import remains. A clean exit is your proof the conversion is total.
+3. **Prove it visually — diff the rendered output against the original, then fix
+   every difference.** A clean build says nothing about whether pixels moved.
+   Render both versions and compare them image-by-image:
+
+   ```bash
+   # a) Build & serve the MIGRATED app. (Static-export shown; for an SSR/dev
+   #    project, start the prod or dev server instead and serve its URL.)
+   <build>; (python3 -m http.server 8731 --directory out &)
+
+   # b) Build & serve the ORIGINAL from the pre-migration ref in a worktree
+   #    (needs its own install — a symlinked node_modules breaks some bundlers).
+   git worktree add /tmp/vrt-old <pre-migration-ref>
+   ( cd /tmp/vrt-old && <install> && <build> )
+   (python3 -m http.server 8732 --directory /tmp/vrt-old/out &)
+
+   # c) Screenshot both at each width with headless Chrome (or Playwright/
+   #    Puppeteer if the project has one). A tall window captures the full page.
+   CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" # adjust per OS
+   for w in 1280 390; do
+     "$CHROME" --headless=new --hide-scrollbars --window-size=$w,2600 \
+       --screenshot=/tmp/vrt/new-$w.png "http://localhost:8731/"
+     "$CHROME" --headless=new --hide-scrollbars --window-size=$w,2600 \
+       --screenshot=/tmp/vrt/old-$w.png "http://localhost:8732/"
+   done
+   ```
+
+   Open each `old`/`new` pair and compare carefully — desktop **and** mobile, plus
+   every state you listed in Phase 0. Theme and interaction states (dark mode, a
+   `:checked` toggle, an expanded `<details>`) can't be reached by a bare
+   screenshot: drive them with Playwright/Puppeteer (set `localStorage`/the theme
+   attribute, click, then capture) or temporarily hardcode the state to render it.
+
+   **For every mismatch, adjust the Tailwind to match the original** — don't
+   rationalize it away. The usual culprits, in rough order of likelihood:
+   - An **unlayered global rule** beating utilities → move it into `@layer base`
+     (Phase 1 / `references/edge-cases.md` → "Cascade layers"). Tell-tale: spacing
+     or text-decoration collapses _site-wide_, not in one component.
+   - A **media query whose direction inverted** (`max-*` vs `min-*`).
+   - An **arbitrary value rounded** to a near scale step → restore the exact value.
+   - A **runtime theme variable frozen** into a static color → back to `var(--…)`.
+   - Tailwind **preflight** changing an element default the old CSS relied on (e.g.
+     heading sizes, `button`/`list` resets) → add the explicit utility/base rule.
+
+   Re-render and re-diff until the pair matches. Distinguish a **real regression**
+   from an **intentional/environment-driven difference** (e.g. a cookie banner that
+   only renders when an analytics env var is set at build time) — note the latter
+   so it isn't chased, but don't use "probably fine" to wave off a real shift.
+   Clean up afterward: `git worktree remove --force /tmp/vrt-old` and stop the
+   servers.
+
+4. **Produce the class-audit report** (`tailwind-migration-report.md` at repo
+   root) so the human can review the mapping without diffing every file. Use
+   this structure:
+
+   ```markdown
+   # CSS Modules → Tailwind migration
+
+   ## Summary
+
+   - Components migrated: N
+   - Module files removed: N
+   - Tailwind set up: yes/no (version)
+
+   ## Per-component mapping
+
+   ### Toggle (src/styles/toggle.module.css → removed)
+
+   | Old class                 | Tailwind utilities                                            |
+   | ------------------------- | ------------------------------------------------------------- |
+   | `.switch`                 | `absolute top-[50px] right-[var(--space-x-2)] … max-md:top-7` |
+   | `input:checked + .slider` | `peer` + `peer-checked:bg-[var(--secondary-color)]`           |
+
+   ## Non-trivial conversions (review these)
+
+   - Header `@keyframes fadeInOutBackground` → `@theme --animate-fade-…`; reason: keyframes can't be inlined.
+   - Icon `:before { content: '\f09b' }` font-icon glyphs kept via `before:content-['\f09b']`.
+
+   ## Theming
+
+   - How dark mode / runtime variables were preserved.
+
+   ## Visual verification
+
+   - States diffed (widths, themes, interaction states) and the result.
+   - Any regression found and how it was fixed (e.g. moved reset into `@layer base`).
+   - Any intentional/env-driven difference noted as NOT a regression.
+   ```
+
+5. **Report honestly.** Show the verify output as evidence, including the
+   visual-diff result (matched / what was fixed). If a rule couldn't become a pure
+   utility (rare, legitimate cases exist — see edge-cases), say so and explain
+   where it lives now, rather than silently approximating. Never report a
+   migration as done on a green build alone — "compiles" is not "looks right."
+
+## Safety principles (the spirit of the skill)
+
+- **One component at a time, verify between each.** Smallest reversible steps.
+- **Exact values over close-enough.** Arbitrary values exist for this reason.
+- **Compiling is not matching.** Prove it visually — diff the rendered output
+  against the original and fix every difference. A green build hides moved pixels.
+- **Keep kept globals in `@layer base`.** An unlayered reset overrides every
+  utility on the page and the build still passes.
+- **Never freeze a runtime variable.** Preserve the theming mechanism first.
+- **Don't delete until it compiles clean.** The module file is the source of
+  truth until the utilities replace it provably.
+- **The report is part of the deliverable**, not an afterthought — it's how the
+  human trusts the migration without re-reading every diff.
+
+## Reference files
+
+- `references/mapping.md` — CSS property/value → Tailwind v4 utility cheatsheet,
+  including arbitrary-value syntax and the default scale.
+- `references/edge-cases.md` — composed/dynamic classNames, `peer` sibling
+  patterns, `max-*` media queries, keyframes, pseudo-elements, theming/dark
+  mode, cascade layers (`@layer base` for kept resets), `@apply`/`@utility`
+  escape hatches, SCSS-specific notes.
+- `references/tailwind-v4-setup.md` — installing/configuring Tailwind v4 in
+  Next.js, `@theme` tokens, custom variants, cascade layers, and upgrading from
+  v3.

--- a/.claude/skills/css-modules-to-tailwind/SKILL.md
+++ b/.claude/skills/css-modules-to-tailwind/SKILL.md
@@ -73,6 +73,12 @@ Run the discovery script to map the work before touching anything:
 node <skill-dir>/scripts/discover.mjs
 ```
 
+> **Limitation:** the discovery script detects only static ES `import` statements.
+> Dynamic imports (`await import('./foo.module.css')`) and `require()` calls are
+> invisible to it. After running the script, also run:
+> `grep -r 'module\.css' src/ --include='*.ts' --include='*.tsx'`
+> to catch any the script missed.
+
 It lists every `*.module.css` / `*.module.scss` file, the components that import
 each, how the import is aliased (`styles`, `icon`, …), and flags files that
 share a module across multiple components (migrate those together). Read its
@@ -105,6 +111,12 @@ Present the plan to the user (files, order, anything that can't become a pure
 utility) and confirm before bulk edits — especially before touching global
 styles or theme tokens.
 
+Also flag any component that **accepts a `className` prop** (forwarding it to the
+root element alongside module classes). Those merges must survive the migration:
+``className={`${styles.base} ${props.className}`}`` becomes
+``className={`flex gap-4 ${props.className ?? ''}`}``. If `clsx` was used only for
+that merging and you remove it, verify the forwarding still works.
+
 ## Phase 1 — Set up Tailwind v4 (only if not already present)
 
 Check first: look for `@import "tailwindcss"` and `tailwindcss` in
@@ -116,9 +128,26 @@ Otherwise install and configure v4 following `references/tailwind-v4-setup.md`.
 The short version for Next.js:
 
 1. `npm i -D tailwindcss @tailwindcss/postcss` (or the project's package manager).
-2. Add the PostCSS plugin (`postcss.config.mjs` → `'@tailwindcss/postcss': {}`).
+2. Add the PostCSS plugin. Check for an **existing** PostCSS config in any of
+   `postcss.config.js`, `postcss.config.mjs`, or `postcss.config.cjs` — add the
+   plugin there rather than creating a new file, because a duplicate config will
+   silently shadow the original. If none exists, create `postcss.config.mjs` with
+   `{ plugins: { '@tailwindcss/postcss': {} } }`.
 3. Put `@import "tailwindcss";` at the top of the global stylesheet (e.g.
    `src/styles/globals.css`) — the one already imported in `_app`.
+
+**Optional but recommended — Prettier Tailwind plugin.** If the project uses
+Prettier (check for `.prettierrc` or `prettier` in `package.json`), install
+`prettier-plugin-tailwindcss` now — before converting any component — so every
+class string lands sorted in canonical order from the start:
+
+```bash
+npm i -D prettier-plugin-tailwindcss
+# then add "plugins": ["prettier-plugin-tailwindcss"] to .prettierrc
+```
+
+Sorted strings are dramatically easier to review and eliminate an entire class of
+"wrong order" mistakes.
 
 **Cascade layers — the regression that compiles clean and still breaks the whole
 page.** Tailwind v4 puts every utility inside `@layer utilities`. Per the CSS
@@ -183,11 +212,24 @@ For each CSS module, smallest first, do this full loop before moving on:
      ``className={`${styles.a} ${icon.b}`}`` → merge both classes' utilities.
    - `clsx` / `classnames` / conditional expressions → keep the conditional
      structure, swap module references for utility strings.
+   - **Dynamic bracket access** (`styles[variantKey]`) — cannot be translated
+     mechanically; expand into a lookup map:
+     `const cls = { primary: 'bg-blue-600', danger: 'bg-red-600' };`
+     then `className={cls[variantKey]}`.
+   - **`className` prop forwarding** — if the component merges a module class
+     with an incoming prop, preserve the merge:
+     ``className={`${styles.base} ${props.className ?? ''}`}``
+     → ``className={`flex gap-4 ${props.className ?? ''}`}``
    - A class used by several elements → expand it at each site (or, if it's
      genuinely repeated and complex, see the `@apply`/`@utility` escape hatch in
      `references/edge-cases.md` — use sparingly; inline utilities are the goal).
 4. **Translate the hard selectors** — don't drop them:
    - `:hover` `:focus` `:active` `:disabled` → `hover:` `focus:` etc.
+   - `:focus-visible` → `focus-visible:`; `:focus-within` → `focus-within:`.
+     **Don't collapse `:focus-visible` into plain `focus:` —** the distinction
+     matters for accessibility: `:focus-visible` shows the ring only for keyboard
+     navigation, not mouse clicks.
+   - `:has(input:checked)` → `has-[input:checked]:` (full browser support in v4).
    - `:before` / `:after` → `before:` / `after:` (content via `content-['…']`).
    - Sibling/checked patterns (`input:checked + .slider`) → the `peer` pattern
      (`peer` on the input, `peer-checked:` on the sibling).
@@ -201,12 +243,22 @@ For each CSS module, smallest first, do this full loop before moving on:
      `references/edge-cases.md`.
 5. **Verify incrementally:** run typecheck (and a build if quick) after each
    component. Catching a break here localizes it to the file you just touched.
-6. **Record** the mapping in the audit report (Phase 3) as you go — old class →
-   new utilities, plus any rule that couldn't become a pure utility and where it
-   lives now.
+   If a browser tab is available, load the component's page/state before moving
+   on — an eyeball catches obvious regressions early and avoids hunting through
+   10 components at Phase 3 for a Phase 2 mistake.
+6. **Record** the mapping immediately — open `tailwind-migration-report.md` and
+   append that component's table right after deleting its module file, before
+   moving to the next component. Building the report incrementally is safer than
+   reconstructing from memory at Phase 3 and less likely to leave gaps.
 7. **Delete** the now-orphaned `.module.css` file and remove its import — but
    only once the importing component(s) compile with no remaining references to
    it. Confirm with a quick grep that no `styles.` (or the alias) usage remains.
+
+   **Mid-migration rollback:** if the tree is in a broken intermediate state,
+   the module file is the source of truth until deleted — restore it from git
+   (`git checkout HEAD -- path/to/foo.module.css`) and revert the component.
+   For a full reset: `git reset --hard <pre-migration-ref>`. This is why Phase 0
+   requires a dedicated branch and a recorded baseline SHA.
 
 ## Phase 3 — Validate and report
 
@@ -232,6 +284,11 @@ For each CSS module, smallest first, do this full loop before moving on:
    ```
    It exits non-zero and lists offenders if any `*.module.{css,scss}` file or
    import remains. A clean exit is your proof the conversion is total.
+   Also locate the TypeScript CSS module declaration file (commonly
+   `src/shared/types/css.d.ts` or any `*.d.ts` containing
+   `declare module '*.module.css'`): now that all modules are deleted it is dead
+   code and may be removed — but confirm no `.module.scss` or other module variant
+   is still in use before doing so.
 3. **Prove it visually — diff the rendered output against the original, then fix
    every difference.** A clean build says nothing about whether pixels moved.
    Render both versions and compare them image-by-image:
@@ -247,15 +304,29 @@ For each CSS module, smallest first, do this full loop before moving on:
    ( cd /tmp/vrt-old && <install> && <build> )
    (python3 -m http.server 8732 --directory /tmp/vrt-old/out &)
 
-   # c) Screenshot both at each width with headless Chrome (or Playwright/
-   #    Puppeteer if the project has one). A tall window captures the full page.
-   CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" # adjust per OS
+   # c) Screenshot both at each width. Prefer Playwright if available
+   #    (cross-platform and handles interaction states natively):
+   mkdir -p /tmp/vrt
+   npx playwright screenshot --full-page http://localhost:8731/ /tmp/vrt/new-1280.png
+   npx playwright screenshot --full-page http://localhost:8732/ /tmp/vrt/old-1280.png
+   # Repeat at mobile width (390) by adding --viewport-size=390,900
+
+   # Headless-Chrome fallback (resolve binary per platform):
+   CHROME=$(\
+     command -v \
+       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+       google-chrome chromium-browser chromium 2>/dev/null | head -1)
    for w in 1280 390; do
      "$CHROME" --headless=new --hide-scrollbars --window-size=$w,2600 \
        --screenshot=/tmp/vrt/new-$w.png "http://localhost:8731/"
      "$CHROME" --headless=new --hide-scrollbars --window-size=$w,2600 \
        --screenshot=/tmp/vrt/old-$w.png "http://localhost:8732/"
    done
+
+   # d) Cleanup — always kill the servers (they bind ports 8731/8732 and will
+   #    conflict with any future run if left alive) and remove the worktree:
+   kill $(lsof -t -i:8731 -i:8732) 2>/dev/null || true
+   git worktree remove --force /tmp/vrt-old
    ```
 
    Open each `old`/`new` pair and compare carefully — desktop **and** mobile, plus
@@ -279,8 +350,7 @@ For each CSS module, smallest first, do this full loop before moving on:
    from an **intentional/environment-driven difference** (e.g. a cookie banner that
    only renders when an analytics env var is set at build time) — note the latter
    so it isn't chased, but don't use "probably fine" to wave off a real shift.
-   Clean up afterward: `git worktree remove --force /tmp/vrt-old` and stop the
-   servers.
+   Cleanup is in step d above.
 
 4. **Produce the class-audit report** (`tailwind-migration-report.md` at repo
    root) so the human can review the mapping without diffing every file. Use

--- a/.claude/skills/css-modules-to-tailwind/SKILL.md
+++ b/.claude/skills/css-modules-to-tailwind/SKILL.md
@@ -36,6 +36,35 @@ files left) is safe only when paired with that discipline.
 
 Work in this order. Each phase exists to shrink the blast radius of a mistake.
 
+## Who runs this (recommended agent)
+
+Run this skill **end-to-end with the `general-purpose` agent on a capable model
+(Opus)** — do not fan it out across subagents and do not drop the driver to a
+low-cost model. Two reasons:
+
+- **Tooling.** The migration must read and _edit_ source, run the discovery
+  script, `tsc`/build, a git worktree, and headless-Chrome screenshots — it needs
+  the full `Read`/`Write`/`Edit`/`Bash`/`Grep`/`Glob` set. That rules out every
+  read-only agent (`Explore`, `Plan`, and the `static-export-guardian` review
+  agent). `general-purpose` is the purpose-built multi-step executor with all
+  tools; the generic `claude` catch-all works too but isn't the specialized fit.
+- **Risk.** This skill exists to prevent regressions that _compile clean_ —
+  inverted media queries, a runtime theme variable frozen static, an unlayered
+  reset beating every utility, pixels that moved under a green build. Those are
+  judgment calls (Phase 1 cascade-layer/theme-token decisions, Phase 3
+  visual-diff adjudication), held across many files with tight cross-phase state
+  (the baseline ref, the running per-component mapping). Per this repo's
+  delegation policy (`CLAUDE.md`), that is exactly the "complex implementation +
+  high-risk review" tier where Opus is justified; a cheaper driver would trade
+  away the very safety this skill is built to provide.
+
+**Keep cost down where it's free to:** the bounded, read-only pieces stay
+low-cost — the deterministic `discover.mjs` + verify gate need no model judgment,
+and the Phase 3 static-export/deploy check is already delegated to the
+**`static-export-guardian`** agent (read-only, `sonnet`). That is where "prefer a
+low-cost agent" applies without compromising quality; the reasoning-heavy driver
+is not.
+
 ## Phase 0 — Discover and plan
 
 Run the discovery script to map the work before touching anything:

--- a/.claude/skills/css-modules-to-tailwind/evals/evals.json
+++ b/.claude/skills/css-modules-to-tailwind/evals/evals.json
@@ -1,0 +1,52 @@
+{
+  "skill_name": "css-modules-to-tailwind",
+  "evals": [
+    {
+      "id": 0,
+      "name": "single-component-toggle",
+      "prompt": "Migrate the theme Toggle component (src/components/Toggle.tsx, styled by src/styles/toggle.module.css and src/styles/icon.module.css) off CSS Modules onto Tailwind. Keep the switch looking and behaving exactly the same — the sliding knob, the checked state, the sun/moon icons, and the mobile position. Remove the toggle CSS module when you're done.",
+      "expected_output": "Toggle.tsx uses Tailwind utilities instead of styles.* references; the sibling/checked behavior is preserved via the peer pattern; the max-width:768px media query becomes max-md:*; the :before content for the slider knob is preserved; toggle.module.css is deleted and its import removed; build + typecheck pass.",
+      "files": [],
+      "expectations": [
+        "Toggle.tsx no longer imports toggle.module.css and contains no styles.* references to it",
+        "src/styles/toggle.module.css is deleted",
+        "The checked-state sibling styling uses the Tailwind peer pattern (peer + peer-checked:)",
+        "The max-width:768px media query is expressed with a max-* variant (e.g. max-md:), not a plain min-width variant",
+        "Exact pixel values are preserved via arbitrary values (e.g. w-[68px], top-[50px]) rather than rounded to the default scale",
+        "Typecheck (tsc --noEmit) passes with no errors",
+        "The static export build succeeds"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "multi-component-keyframes-responsive",
+      "prompt": "Move the Header and CookieConsent components to Tailwind, dropping their CSS modules (src/styles/header.module.css, src/styles/cookieConsent.module.css). The look must stay identical — including the logo's hover animation, the gradient text clip, and the layouts collapsing to a column on small screens. Set up Tailwind v4 if the project doesn't have it yet.",
+      "expected_output": "Tailwind v4 is installed and imported in globals.css; Header.tsx and CookieConsent.tsx use utilities; the @keyframes fadeInOutBackground animation is preserved (defined in @theme, triggered via an animate-* utility on hover); the gradient + background-clip:text is preserved; max-width media queries become max-* variants; both module files are deleted; build + typecheck pass.",
+      "files": [],
+      "expectations": [
+        "Tailwind v4 is set up: @import \"tailwindcss\" is present in the global stylesheet and tailwindcss is a dependency",
+        "header.module.css and cookieConsent.module.css are both deleted and their imports removed",
+        "The @keyframes animation is preserved (kept in CSS/@theme) and triggered via a hover utility, not dropped",
+        "The responsive column-collapse uses max-* variants matching the original max-width breakpoints",
+        "The gradient text effect (background-clip:text) is preserved via an arbitrary property or utility",
+        "Typecheck passes and the static export build succeeds"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "full-project-migration",
+      "prompt": "Convert this whole project from CSS Modules to Tailwind CSS v4. Set up Tailwind, port every component's styles to utility classes, preserve the light/dark theme (it's driven by the html[data-theme='dark'] attribute swapping CSS variables), remove all the *.module.css files, and give me a report of what changed. The site must look and behave identically and still build as a static export.",
+      "expected_output": "Tailwind v4 set up; all 10 CSS module files migrated to utilities and deleted; no remaining .module.css imports; the [data-theme='dark'] theming mechanism is preserved (runtime CSS variables NOT frozen into static @theme tokens); a migration report is produced; lint + typecheck + static build all pass.",
+      "files": [],
+      "expectations": [
+        "No *.module.css files remain anywhere in src/ and no component imports one",
+        "Tailwind v4 is configured (@import \"tailwindcss\" in globals, PostCSS plugin, dependency added)",
+        "The html[data-theme='dark'] block and its CSS variables are preserved as runtime custom properties (theme switching still works), not baked into static @theme color tokens",
+        "Color/spacing values are referenced via the existing CSS variables or arbitrary values, preserving exact appearance",
+        "A migration report (markdown) is produced summarizing per-component class mappings",
+        "next.config.mjs static export settings (output:'export', images.unoptimized, trailingSlash) are unchanged",
+        "Lint, typecheck, and the static export build all pass"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/css-modules-to-tailwind/evals/evals.json
+++ b/.claude/skills/css-modules-to-tailwind/evals/evals.json
@@ -47,6 +47,22 @@
         "next.config.mjs static export settings (output:'export', images.unoptimized, trailingSlash) are unchanged",
         "Lint, typecheck, and the static export build all pass"
       ]
+    },
+    {
+      "id": 3,
+      "name": "tailwind-v4-setup-only",
+      "prompt": "This project uses CSS Modules and has no Tailwind at all. Set up Tailwind CSS v4 without migrating any component yet — install the packages, wire up the PostCSS plugin, add the @import to globals.css, and make sure the build still passes and nothing looks broken.",
+      "expected_output": "tailwindcss and @tailwindcss/postcss added to devDependencies; a postcss.config.mjs (or equivalent) created with the @tailwindcss/postcss plugin; @import 'tailwindcss' added at the top of globals.css; existing global rules wrapped in @layer base where needed so they don't override utilities; build and typecheck pass; no CSS Module files or imports are touched.",
+      "files": [],
+      "expectations": [
+        "tailwindcss and @tailwindcss/postcss are in package.json devDependencies",
+        "A PostCSS config file exists with @tailwindcss/postcss as a plugin (no duplicate config files)",
+        "@import 'tailwindcss' is the first declaration in the global stylesheet",
+        "Any unlayered global reset rules (*, a, body, ol, ul) below the @import are moved into @layer base",
+        ":root and [data-theme='dark'] custom-property blocks remain unlayered",
+        "No *.module.css files are modified or deleted",
+        "Typecheck and the static export build pass with no errors"
+      ]
     }
   ]
 }

--- a/.claude/skills/css-modules-to-tailwind/references/edge-cases.md
+++ b/.claude/skills/css-modules-to-tailwind/references/edge-cases.md
@@ -1,0 +1,301 @@
+# Edge cases — the patterns that break naive migrations
+
+Read this before migrating. Each section is a place where a literal translation
+produces wrong output. Examples use realistic React/CSS-Module code.
+
+## Table of contents
+
+1. Dynamic & composed classNames
+2. Media queries → `max-*` variants (mobile-first trap)
+3. Sibling / checked selectors → `peer`
+4. Child & descendant selectors
+5. Pseudo-elements (`:before`/`:after`) and font-icon content
+6. `@keyframes` and animations
+7. Theming / dark mode / runtime CSS variables
+8. The `@apply` / `@utility` escape hatch
+9. SCSS modules (`composes`, nesting, `&`, variables)
+10. `:global`, multiple classes, and gotchas
+11. Cascade layers — kept resets must live in `@layer base`
+
+---
+
+## 1. Dynamic & composed classNames
+
+CSS Modules get referenced many ways. Preserve the _structure_; swap only the
+module reference for the utility string.
+
+```tsx
+// Template literal mixing two modules + a font variable:
+<i className={`${fontello.variable} ${icon.sun} ${styles.icon__sun}`} />
+// → keep the font variable, expand icon.sun and styles.icon__sun:
+<i className={`${fontello.variable} before:content-['\\e801'] absolute top-1 left-1 z-0`} />
+
+// clsx / classnames:
+className={clsx(styles.btn, isActive && styles.active)}
+// → className={clsx('px-4 py-2 rounded-md', isActive && 'bg-black text-white')}
+
+// Conditional ternary:
+className={open ? styles.open : styles.closed}
+// → className={open ? 'block' : 'hidden'}
+```
+
+When a long utility string is used conditionally, a readable pattern is to hoist
+the strings to `const` above the JSX. Don't over-engineer — inline is fine for
+short ones.
+
+## 2. Media queries → `max-*` variants (the mobile-first trap)
+
+Tailwind variants are **min-width** by default. A `max-width` media query must
+become a `max-*` variant or the breakpoint inverts.
+
+```css
+@media (max-width: 768px) {
+  .switch {
+    top: 28px;
+  }
+}
+```
+
+`max-width: 768px` ≈ Tailwind's `md` boundary → use **`max-md:`**:
+
+```tsx
+<label className="... top-[50px] max-md:top-7" />
+```
+
+- `max-width: 640px` → `max-sm:`
+- `max-width: 768px` → `max-md:`
+- `max-width: 1024px` → `max-lg:`
+- A non-standard breakpoint → arbitrary: `max-[900px]:flex-col`.
+
+`min-width: 768px` → plain `md:`. **Always re-check direction per query** — this
+is the most common silent regression.
+
+## 3. Sibling / checked selectors → `peer`
+
+The classic toggle: a hidden checkbox styles its sibling.
+
+```css
+.slider {
+  background: var(--contrast-color);
+}
+input[type='checkbox']:checked + .slider {
+  background: var(--secondary-color);
+}
+input[type='checkbox']:checked + .slider:before {
+  transform: translateX(34px);
+}
+```
+
+Mark the controlling input `peer`, style siblings with `peer-checked:`:
+
+```tsx
+<input type="checkbox" className="peer sr-only" />
+<span className="bg-[var(--contrast-color)] peer-checked:bg-[var(--secondary-color)]
+                 before:translate-x-0 peer-checked:before:translate-x-[34px]" />
+```
+
+`peer` requires the styled element to be a **later sibling** of the peer (matches
+`+`/`~`). For parent-state styling use `group` / `group-hover:` instead.
+
+## 4. Child & descendant selectors
+
+```css
+.logo > span {
+  display: none;
+} /* hide a specific child */
+```
+
+Two options, prefer the first when you control the markup:
+
+- Move the utility onto the child: `<span className="hidden">`.
+- Arbitrary variant on the parent: `className="[&>span]:hidden"`.
+
+Descendant (`.card .title`) → `[&_.title]:…` or, better, put the class on the
+title element. Deep selector chains are a smell — restructuring to put classes
+where they belong is usually cleaner than nesting arbitrary variants.
+
+## 5. Pseudo-elements and font-icon content
+
+`:before`/`:after` map to `before:`/`after:` variants. Tailwind auto-injects
+`content: ''` when you use `before:`, but set it explicitly when there's real
+content. **Content must be quoted inside the bracket and unicode escapes need a
+doubled backslash in TSX strings.**
+
+```css
+.github:before {
+  content: '\f09b';
+  font-family: var(--font-fontello);
+}
+```
+
+```tsx
+<i
+  className="before:content-['\\f09b'] before:font-[var(--font-fontello)]
+              before:inline-block before:w-10 before:h-10 before:leading-10
+              before:text-center before:text-[2rem]"
+/>
+```
+
+This is verbose. Font-icon classes reused across many elements are a legitimate
+case for an `@utility` (section 8) — converting to that is still "off CSS
+modules" and keeps markup clean. Decide based on repetition.
+
+## 6. `@keyframes` and animations
+
+Keyframes can't be inlined. In v4, define them in the global stylesheet's
+`@theme` block, which generates an `animate-*` utility:
+
+```css
+/* globals.css */
+@theme {
+  --animate-fade-bg: fade-bg 0.4s ease-in-out;
+  @keyframes fade-bg {
+    0%,
+    100% {
+      background-color: transparent;
+    }
+    50% {
+      color: var(--primary-color);
+      background: var(--secondary-color);
+    }
+  }
+}
+```
+
+```tsx
+// .logo:hover { animation: fadeInOutBackground 0.4s ...; }  →
+<h1 className="hover:animate-fade-bg" />
+```
+
+Keep the `@keyframes` definition; only its _trigger_ moves to a utility.
+
+## 7. Theming / dark mode / runtime CSS variables — read carefully
+
+This is where migrations most often break subtly. If the project swaps CSS
+variable _values_ at runtime (theme toggle), those variables must stay live CSS
+custom properties — **never freeze them into static `@theme` colors.**
+
+Pattern in this kind of project:
+
+```css
+:root {
+  --primary-color: #fff;
+  --secondary-color: #1c1c1c;
+}
+html[data-theme='dark'] {
+  --primary-color: #1c1c1c;
+  --secondary-color: #fff;
+}
+```
+
+Migration:
+
+- **Keep** the `:root` and `html[data-theme='dark']` blocks exactly as-is in the
+  global stylesheet. They are the theme engine.
+- Reference the variables from utilities with arbitrary values:
+  `bg-[var(--primary-color)] text-[var(--secondary-color)]`. Because the
+  variable is resolved at runtime, theme switching keeps working for free.
+- If the project uses `prefers-color-scheme` or a `.dark` class instead, you can
+  use Tailwind's `dark:` variant — but only when colors are otherwise static.
+- For a non-standard trigger like `[data-theme='dark']`, register a variant so
+  `dark:` works if you want it:
+  ```css
+  @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+  ```
+
+Decision rule: **does any selector override this variable's value?** If yes, it's
+a runtime variable — keep it as a CSS custom property. If no, it's a static
+token and may go in `@theme`.
+
+## 8. The `@apply` / `@utility` escape hatch
+
+The goal is inline utilities, but two cases justify a named class — and both
+still remove the `.module.css` file, so they satisfy "off CSS Modules":
+
+- **Reused complex pattern** (a font-icon glyph set, a button style on 8 sites).
+- **Markup you can't edit** (rendering raw HTML, `dangerouslySetInnerHTML`,
+  third-party DOM) where you can't attach classes to elements.
+
+v4 syntax in the global stylesheet:
+
+```css
+@utility btn {
+  @apply px-4 py-2 rounded-md font-semibold border border-[var(--secondary-color)];
+}
+```
+
+Use sparingly. If you find yourself `@apply`-ing everything, the migration isn't
+really moving to utilities — prefer inlining.
+
+## 9. SCSS modules (`.module.scss`)
+
+- **`composes: base from './x.module.scss'`** → there's no Tailwind equivalent;
+  inline the composed class's utilities at every use site, or make an `@utility`.
+- **Nesting / `&`** → flatten. `&:hover` → `hover:`; nested `.child` → move class
+  to the child or use `[&_.child]:`.
+- **SCSS variables / mixins / functions** (`$color`, `@mixin`, `lighten()`) →
+  resolve to concrete values first (compute the final CSS), then map. Tailwind
+  has no build-time SCSS; don't try to preserve the SCSS abstractions.
+- After migration, the file is plain enough to delete along with its import.
+
+## 10. `:global`, multiple classes, and gotchas
+
+- `:global(.foo)` in a module targets a global class — that styling likely
+  belongs in the global stylesheet or as utilities on the element; don't lose it.
+- A rule with **multiple selectors** (`.accept:hover, .reject:hover { opacity: .85 }`)
+  → apply `hover:opacity-[0.85]` to _both_ elements.
+- **`*` universal / element resets** (`* { margin: 0 }`, `a { color: inherit }`)
+  live in the global stylesheet, not a module — usually leave them, or let
+  Tailwind's preflight handle resets. Don't try to inline a `*` selector.
+- **Specificity**: utilities are flat; if old CSS relied on cascade order,
+  verify the visual result rather than assuming the class order matches.
+
+## 11. Cascade layers — kept resets must live in `@layer base`
+
+The highest-impact silent regression in a v4 migration, and the easiest to miss
+because it **compiles clean**. `@import "tailwindcss"` puts every utility inside
+`@layer utilities`. By the CSS cascade-layers rule, **an unlayered rule beats any
+layered rule regardless of specificity** — so a global reset left unlayered in
+`globals.css` overrides your utilities site-wide.
+
+```css
+@import 'tailwindcss';
+* {
+  margin: 0;
+  padding: 0;
+} /* unlayered → beats .mt-8, .p-8, .mx-8 … */
+a {
+  text-decoration: none;
+} /* unlayered → beats .underline */
+```
+
+Symptom: not one broken component but **whole-page** collapse of whatever the
+reset touches — all spacing gone, all underlines gone — while colors, borders,
+grid, and fonts (which the reset doesn't touch) look fine. That "only margins and
+underlines are wrong, everywhere" signature is the fingerprint.
+
+Fix — move the project's base element rules into `@layer base`:
+
+```css
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+}
+```
+
+Keep unlayered on purpose: `:root` / `[data-theme]` **custom-property** blocks
+(no conflict with utilities) and deliberate always-win helpers like `.sr-only`.
+Full recipe and rationale in `tailwind-v4-setup.md` → "Cascade layers". This is
+exactly what the Phase 3 visual diff is built to catch — if spacing looks
+collapsed in the `new` screenshot but the build was green, suspect this first.

--- a/.claude/skills/css-modules-to-tailwind/references/edge-cases.md
+++ b/.claude/skills/css-modules-to-tailwind/references/edge-cases.md
@@ -13,9 +13,11 @@ produces wrong output. Examples use realistic React/CSS-Module code.
 6. `@keyframes` and animations
 7. Theming / dark mode / runtime CSS variables
 8. The `@apply` / `@utility` escape hatch
-9. SCSS modules (`composes`, nesting, `&`, variables)
+9. CSS `composes` and SCSS modules
 10. `:global`, multiple classes, and gotchas
 11. Cascade layers — kept resets must live in `@layer base`
+12. Focus and `:has()` pseudo-classes
+13. `@supports` feature queries
 
 ---
 
@@ -37,6 +39,25 @@ className={clsx(styles.btn, isActive && styles.active)}
 // Conditional ternary:
 className={open ? styles.open : styles.closed}
 // → className={open ? 'block' : 'hidden'}
+
+// Dynamic bracket access — cannot be translated mechanically:
+className={styles[variant]}  // variant: 'primary' | 'danger'
+// → expand into a lookup map:
+const cls: Record<string, string> = {
+  primary: 'bg-blue-600 text-white',
+  danger:  'bg-red-600 text-white',
+};
+className={cls[variant]}
+
+// className prop forwarding (component accepts an external className):
+className={`${styles.base} ${props.className ?? ''}`}
+// → className={`flex gap-4 ${props.className ?? ''}`}
+
+// cn() / twMerge (common in shadcn/ui-style components):
+className={cn(styles.btn, props.className)}
+// → className={cn('px-4 py-2 rounded-md', props.className)}
+// twMerge deduplicates conflicting utilities; if the project doesn't have it,
+// this migration is a good time to add it wherever className props are forwarded.
 ```
 
 When a long utility string is used conditionally, a readable pattern is to hoist
@@ -203,9 +224,34 @@ Migration:
   @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
   ```
 
+**`@theme inline` — the best of both worlds.** If you want a named utility
+(`bg-primary`, `text-primary`) that stays theme-aware at runtime, use
+`@theme inline`. It emits `var(--primary-color)` into the utility instead of
+freezing the resolved value at build time:
+
+```css
+:root {
+  --primary-color: #fff;
+}
+html[data-theme='dark'] {
+  --primary-color: #1c1c1c;
+}
+
+@theme inline {
+  --color-primary: var(--primary-color);
+}
+/* → bg-primary compiles to: background-color: var(--primary-color) */
+/* → theme toggle still works at runtime */
+```
+
+Without `inline`, Tailwind would snapshot the value at build time and the theme
+toggle would break. Use `@theme inline` whenever you want a named utility wrapping
+a runtime CSS variable. See `tailwind-v4-setup.md` → "`@theme`" for the full
+namespace list.
+
 Decision rule: **does any selector override this variable's value?** If yes, it's
-a runtime variable — keep it as a CSS custom property. If no, it's a static
-token and may go in `@theme`.
+a runtime variable — keep it as a CSS custom property (with or without
+`@theme inline`). If no, it's a static token and may go directly in `@theme`.
 
 ## 8. The `@apply` / `@utility` escape hatch
 
@@ -227,10 +273,34 @@ v4 syntax in the global stylesheet:
 Use sparingly. If you find yourself `@apply`-ing everything, the migration isn't
 really moving to utilities — prefer inlining.
 
-## 9. SCSS modules (`.module.scss`)
+## 9. CSS `composes` and SCSS modules
 
-- **`composes: base from './x.module.scss'`** → there's no Tailwind equivalent;
-  inline the composed class's utilities at every use site, or make an `@utility`.
+**Standard CSS Modules `composes`** works in plain `.module.css` files too, not
+just SCSS. It creates a cross-file dependency that the discover script cannot see:
+
+```css
+/* button.module.css */
+.btn-primary {
+  composes: btn from './base.module.css';
+  color: green;
+}
+```
+
+When `base.module.css` is deleted during its own migration, `btn-primary` silently
+loses the composed styles. **Always migrate the composed-from file last**, or
+migrate it together with every file that composes from it. Before finalizing the
+migration order, run:
+
+```bash
+grep -r 'composes:' src/ --include='*.module.css'
+```
+
+Translate `composes` by inlining the composed class's utilities at every use site,
+or create an `@utility` if the pattern recurs. There is no Tailwind equivalent.
+
+For SCSS-specific patterns:
+
+- **`composes: base from './x.module.scss'`** → same as above.
 - **Nesting / `&`** → flatten. `&:hover` → `hover:`; nested `.child` → move class
   to the child or use `[&_.child]:`.
 - **SCSS variables / mixins / functions** (`$color`, `@mixin`, `lighten()`) →
@@ -299,3 +369,61 @@ Keep unlayered on purpose: `:root` / `[data-theme]` **custom-property** blocks
 Full recipe and rationale in `tailwind-v4-setup.md` → "Cascade layers". This is
 exactly what the Phase 3 visual diff is built to catch — if spacing looks
 collapsed in the `new` screenshot but the build was green, suspect this first.
+
+---
+
+## 12. Focus and `:has()` pseudo-classes
+
+Commonly overlooked during migration:
+
+- `:focus-visible` → `focus-visible:` — **accessibility critical**. A CSS Module
+  that hides the default ring and restores it only on `:focus-visible` must keep
+  this distinction. Collapsing it to plain `focus:` shows the ring on mouse clicks
+  too, which is a visible regression for sighted mouse users.
+- `:focus-within` → `focus-within:` — styles the parent when any child has focus.
+- `:has()` → `has-[selector]:` — full browser support; Tailwind v4 supports it.
+
+```css
+/* CSS Modules */
+.field:focus-within label {
+  color: var(--primary-color);
+}
+.card:has(input:checked) {
+  border-color: green;
+}
+.btn:focus:not(:focus-visible) {
+  outline: none;
+}
+.btn:focus-visible {
+  outline: 2px solid var(--primary-color);
+}
+```
+
+```tsx
+<div className="focus-within:[&>label]:text-[var(--primary-color)]">
+<div className="has-[input:checked]:border-green-500">
+<button className="focus:outline-none focus-visible:outline-2 focus-visible:outline-[var(--primary-color)]">
+```
+
+## 13. `@supports` feature queries
+
+Some modules use `@supports` for progressive enhancement. Tailwind has no
+dedicated variant — use an arbitrary variant:
+
+```css
+@supports (display: grid) {
+  .layout {
+    display: grid;
+    gap: 1rem;
+  }
+}
+```
+
+```tsx
+className = '[@supports(display:grid)]:grid [@supports(display:grid)]:gap-4';
+```
+
+For a block with many properties inside a single `@supports` query, the arbitrary
+variant approach becomes verbose. In that case, move the `@supports` block to the
+global stylesheet as a kept CSS rule (outside any module file) and leave a comment
+explaining why — don't force every declaration into an arbitrary variant.

--- a/.claude/skills/css-modules-to-tailwind/references/mapping.md
+++ b/.claude/skills/css-modules-to-tailwind/references/mapping.md
@@ -1,0 +1,102 @@
+# CSS → Tailwind v4 utility cheatsheet
+
+Use this to translate declarations. The golden rule: **if the value isn't on
+Tailwind's default scale, use an arbitrary value `[…]` to keep it exact.** Do
+not round `top: 50px` to `top-12`. Regressions hide in "close enough."
+
+Arbitrary value syntax: `property-[value]` → `w-[68px]`, `top-[var(--x)]`,
+`bg-[#1c1c1c]`, `grid-cols-[1fr_2fr]` (spaces become underscores).
+
+## Default scale quick reference
+
+- **Spacing** (`p`, `m`, `gap`, `w`, `h`, `top`…): `1` = `0.25rem` (4px). So
+  `0.5rem`→`2`, `1rem`→`4`, `2rem`→`8`, `4rem`→`16`. `px` = `1px`. Anything off
+  the 4px grid → arbitrary: `gap-[18px]`.
+- **Breakpoints** (min-width by default): `sm` 640, `md` 768, `lg` 1024, `xl`
+  1280, `2xl` 1536.
+- **font-weight**: `font-normal` 400, `font-medium` 500, `font-semibold` 600,
+  `font-bold` 700. Off-scale → `font-[450]`.
+- **z-index**: `z-0`, `z-10`…`z-50`, `z-auto`; off-scale → `z-[1000]`.
+- **border-radius**: `rounded-sm/md/lg/xl/full`; exact → `rounded-[0.375rem]`.
+- **opacity**: `opacity-0`…`opacity-100` in steps; `opacity-[0.85]` otherwise.
+
+## Layout & box model
+
+| CSS                                 | Tailwind                                                |
+| ----------------------------------- | ------------------------------------------------------- |
+| `display: flex`                     | `flex`                                                  |
+| `display: inline-block`             | `inline-block`                                          |
+| `display: grid`                     | `grid`                                                  |
+| `display: none`                     | `hidden`                                                |
+| `flex-direction: column`            | `flex-col`                                              |
+| `flex-wrap: wrap`                   | `flex-wrap`                                             |
+| `flex-shrink: 0`                    | `shrink-0`                                              |
+| `justify-content: space-between`    | `justify-between`                                       |
+| `align-items: center`               | `items-center`                                          |
+| `align-items: flex-start`           | `items-start`                                           |
+| `gap: 2rem`                         | `gap-8` (or `gap-[var(--space-x-2)]` to keep the token) |
+| `position: absolute/fixed/relative` | `absolute` / `fixed` / `relative`                       |
+| `top/right/bottom/left: 0`          | `inset-0` (all four) or `top-0` etc.                    |
+| `overflow: hidden`                  | `overflow-hidden`                                       |
+| `box-sizing: border-box`            | `box-border`                                            |
+| `width: 100vw` / `100%`             | `w-screen` / `w-full`                                   |
+| `max-width: 1024px`                 | `max-w-[1024px]` (or `max-w-screen-lg`)                 |
+
+## Typography
+
+| CSS                       | Tailwind                                           |
+| ------------------------- | -------------------------------------------------- |
+| `font-size: 0.875rem`     | `text-sm` (matches scale) — else `text-[0.875rem]` |
+| `font-size: 400%`         | `text-[400%]`                                      |
+| `font-weight: 600`        | `font-semibold`                                    |
+| `line-height: 1.4`        | `leading-[1.4]`                                    |
+| `line-height: 100%`       | `leading-none`                                     |
+| `letter-spacing: -0.2rem` | `tracking-[-0.2rem]`                               |
+| `text-align: center`      | `text-center`                                      |
+| `text-decoration: none`   | `no-underline`                                     |
+| `text-transform: none`    | `normal-case`                                      |
+| `color: inherit`          | `text-inherit`                                     |
+| `color: var(--x)`         | `text-[var(--x)]`                                  |
+| `white-space: nowrap`     | `whitespace-nowrap`                                |
+
+## Color, background, border
+
+| CSS                                       | Tailwind                                                                                |
+| ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `color: #555`                             | `text-[#555]`                                                                           |
+| `background-color: var(--primary-color)`  | `bg-[var(--primary-color)]`                                                             |
+| `background: transparent`                 | `bg-transparent`                                                                        |
+| `background-image: linear-gradient(...)`  | `bg-[linear-gradient(...)]` (underscores for spaces) or v4 `bg-linear-to-r from-… to-…` |
+| `border: 1px solid var(--x)`              | `border border-[var(--x)]`                                                              |
+| `border-top: 5px solid #fff`              | `border-t-[5px] border-t-white`                                                         |
+| `border-radius: 50%`                      | `rounded-full`                                                                          |
+| `border-radius: 34px`                     | `rounded-[34px]`                                                                        |
+| `box-shadow: 0 4px 16px rgb(0 0 0 / 15%)` | `shadow-[0_4px_16px_rgb(0_0_0_/_15%)]`                                                  |
+
+## Transitions, transforms, misc
+
+| CSS                                                       | Tailwind                                                          |
+| --------------------------------------------------------- | ----------------------------------------------------------------- |
+| `transition: all 0.2s`                                    | `transition-all duration-200`                                     |
+| `transition: color 0.2s ease, background-color 0.2s ease` | `transition-[color,background-color] duration-200 ease-out`       |
+| `transform: translateX(34px)`                             | `translate-x-[34px]`                                              |
+| `transform: rotateX(360deg)`                              | `[transform:rotateX(360deg)]` (no util)                           |
+| `transform: translateX(-50%)`                             | `-translate-x-1/2`                                                |
+| `cursor: pointer`                                         | `cursor-pointer`                                                  |
+| `opacity: 0`                                              | `opacity-0`                                                       |
+| `backface-visibility: hidden`                             | `[backface-visibility:hidden]`                                    |
+| `content: ''`                                             | `content-['']` (on `before:`/`after:`)                            |
+| `list-style: none`                                        | `list-none`                                                       |
+| `-webkit-font-smoothing: antialiased`                     | `antialiased`                                                     |
+| `width: 0; height: 0`                                     | `w-0 h-0`                                                         |
+| `calc(100% - 2rem)`                                       | `w-[calc(100%-2rem)]` (no spaces inside calc, or use underscores) |
+
+## Properties with no clean utility
+
+Use the **arbitrary property** syntax `[property:value]` for anything Tailwind
+doesn't model: `[backface-visibility:hidden]`, `[transform:rotateX(360deg)]`,
+`[-webkit-background-clip:text]`, `[background-clip:text]`,
+`[color-scheme:light_dark]`, `[text-rendering:optimizeLegibility]`.
+
+If a single element accumulates many of these, that's a signal to consider an
+`@utility` or `@apply` class instead — see `edge-cases.md`.

--- a/.claude/skills/css-modules-to-tailwind/references/mapping.md
+++ b/.claude/skills/css-modules-to-tailwind/references/mapping.md
@@ -90,6 +90,13 @@ Arbitrary value syntax: `property-[value]` → `w-[68px]`, `top-[var(--x)]`,
 | `-webkit-font-smoothing: antialiased`                     | `antialiased`                                                     |
 | `width: 0; height: 0`                                     | `w-0 h-0`                                                         |
 | `calc(100% - 2rem)`                                       | `w-[calc(100%-2rem)]` (no spaces inside calc, or use underscores) |
+| `will-change: transform`                                  | `will-change-transform`                                           |
+| `will-change: contents`                                   | `will-change-contents`                                            |
+| `pointer-events: none`                                    | `pointer-events-none`                                             |
+| `pointer-events: auto`                                    | `pointer-events-auto`                                             |
+| `user-select: none`                                       | `select-none`                                                     |
+| `resize: none`                                            | `resize-none`                                                     |
+| `scroll-behavior: smooth`                                 | `scroll-smooth`                                                   |
 
 ## Properties with no clean utility
 

--- a/.claude/skills/css-modules-to-tailwind/references/tailwind-v4-setup.md
+++ b/.claude/skills/css-modules-to-tailwind/references/tailwind-v4-setup.md
@@ -1,0 +1,181 @@
+# Tailwind v4 setup in Next.js
+
+Tailwind v4 is **CSS-first**: configuration lives in your CSS via `@import` and
+`@theme`, not a big `tailwind.config.js`. There are no `content` globs to
+maintain — v4 auto-detects template files.
+
+## Fresh install (project has no Tailwind)
+
+1. **Install** (match the project's package manager — check for
+   `yarn.lock` / `pnpm-lock.yaml` / `package-lock.json`):
+
+   ```bash
+   npm i -D tailwindcss @tailwindcss/postcss
+   # yarn add -D tailwindcss @tailwindcss/postcss
+   ```
+
+2. **PostCSS plugin.** Create or edit `postcss.config.mjs`:
+
+   ```js
+   const config = { plugins: { '@tailwindcss/postcss': {} } };
+   export default config;
+   ```
+
+   (If a `postcss.config.js` already exists, add the plugin there; don't create a
+   duplicate config.)
+
+3. **Import Tailwind** at the very top of the global stylesheet that's already
+   imported once in `_app.tsx` (commonly `src/styles/globals.css`):
+
+   ```css
+   @import 'tailwindcss';
+   ```
+
+   Keep the file's existing global rules below the import.
+
+4. **Verify** the build before migrating components:
+   ```bash
+   npx tsc --noEmit && <project build command>
+   ```
+
+No `tailwind.config.js` is required for v4. Only add one (via
+`@config "./tailwind.config.js";`) if you need a plugin that hasn't moved to the
+CSS API.
+
+## Cascade layers — keep kept global styles in `@layer base`
+
+`@import "tailwindcss"` declares `@layer theme, base, components, utilities;` and
+puts every generated utility in `@layer utilities`. The CSS cascade-layers rule
+is: **unlayered styles beat layered styles regardless of specificity.** So any
+plain rule left below the `@import` in your global stylesheet outranks every
+Tailwind utility.
+
+This bites hardest with the resets a CSS-Modules project keeps in `globals.css`:
+
+```css
+@import 'tailwindcss';
+
+/* WRONG: unlayered — overrides p-8, mt-8, mx-8, underline, … everywhere */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+a {
+  text-decoration: none;
+}
+```
+
+The build passes, but margins/paddings/underlines collapse across the whole site
+because `* { margin: 0 }` wins over `.mt-8`. Fix: put the project's base element
+rules in `@layer base` (where preflight lives), so utilities can override them.
+
+```css
+@import 'tailwindcss';
+
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+  html,
+  body {
+    /* … */
+  }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+}
+```
+
+Leave these **unlayered** on purpose:
+
+- `:root { --x: … }` and theme-selector blocks (`html[data-theme='dark']`) — they
+  declare custom properties and don't compete with utilities; layering them can
+  perturb token precedence.
+- Intentional "always win" helpers like `.sr-only` — you _want_ them to beat
+  utilities.
+
+Note: much of a hand-written reset (universal `margin/padding/box-sizing`, `ol/ul`
+list-style, heading margins) duplicates Tailwind v4 **preflight**, which already
+runs in `@layer base`. You can often delete the redundant parts and keep only the
+project-specific rules — but verify visually before removing anything.
+
+## `@theme` — design tokens that generate utilities
+
+`@theme` turns custom properties into utilities. Naming follows namespaces:
+
+```css
+@theme {
+  --color-brand: #3b82f6; /* → bg-brand, text-brand, border-brand */
+  --spacing-gutter: 2rem; /* → p-gutter, gap-gutter, m-gutter */
+  --font-display: 'Inter', sans-serif; /* → font-display */
+  --breakpoint-3xl: 120rem; /* → 3xl: variant */
+  --animate-fade-bg: fade-bg 0.4s ease-in-out; /* → animate-fade-bg */
+}
+```
+
+Namespaces: `--color-*`, `--spacing-*`, `--font-*`, `--text-*` (font-size),
+`--font-weight-*`, `--radius-*`, `--shadow-*`, `--breakpoint-*`, `--animate-*`,
+`--ease-*`, `--leading-*`, `--tracking-*`.
+
+**Only put STATIC tokens here.** A value that changes at runtime (theme toggle)
+must stay an ordinary CSS variable outside `@theme` — see
+`edge-cases.md` section 7. If an existing `:root` has a mix, split it: static
+ones into `@theme`, runtime-swapped ones left in `:root`/theme-selector blocks.
+
+You can reference a kept CSS variable inside `@theme` so it still produces a
+utility while staying dynamic:
+
+```css
+:root {
+  --primary-color: #fff;
+}
+html[data-theme='dark'] {
+  --primary-color: #1c1c1c;
+}
+@theme inline {
+  --color-primary: var(--primary-color);
+} /* bg-primary stays theme-aware */
+```
+
+The `inline` keyword makes the utility emit `var(--primary-color)` rather than
+freezing the value — exactly what runtime theming needs.
+
+## Custom variants
+
+```css
+/* Make dark: respond to a [data-theme="dark"] attribute instead of media/class */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+```
+
+## Upgrading from Tailwind v3
+
+If the project already has v3 (`tailwind.config.js` with `content`, `theme`,
+`plugins`):
+
+1. Try the official codemod first: `npx @tailwindcss/upgrade`. It migrates config
+   to CSS, rewrites deprecated utilities, and updates PostCSS. Review its diff.
+2. Manual essentials if not using the codemod:
+   - Replace `@tailwind base; @tailwind components; @tailwind utilities;` with a
+     single `@import "tailwindcss";`.
+   - Move `theme.extend` tokens into `@theme { … }`.
+   - Swap the PostCSS plugin `tailwindcss` → `@tailwindcss/postcss`; remove
+     `autoprefixer`/`postcss-import` (v4 includes them).
+   - Renamed utilities: `shadow-sm`→`shadow-xs`, `shadow`→`shadow-sm`,
+     `rounded`→`rounded-sm`, `blur`→`blur-sm`, `outline-none`→`outline-hidden`.
+     The codemod handles these; if doing it by hand, grep for the old names.
+3. Re-run the build and check for removed-default warnings.
+
+## Static-export / SSG projects
+
+Tailwind v4 produces a plain CSS file at build time with no runtime — fully
+compatible with `output: 'export'` and static hosting. Nothing about the
+migration adds a server dependency. Don't introduce runtime CSS-in-JS as a
+"bridge"; that would break a static export.

--- a/.claude/skills/css-modules-to-tailwind/scripts/discover.mjs
+++ b/.claude/skills/css-modules-to-tailwind/scripts/discover.mjs
@@ -12,7 +12,9 @@
 // `icon`) so you know what to grep for when rewriting JSX.
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, extname } from 'node:path';
+import { extname, join, relative } from 'node:path';
+
+/* eslint-disable no-console */
 
 const ROOT = process.cwd();
 const CHECK = process.argv.includes('--check');
@@ -60,22 +62,23 @@ const importRe =
 let strayImports = 0;
 for (const sf of sourceFiles) {
   const text = readFileSync(sf, 'utf8');
-  let m;
-  while ((m = importRe.exec(text)) !== null) {
-    const alias = m[1] || m[2];
-    const spec = m[3];
+  let match;
+  while ((match = importRe.exec(text)) !== null) {
+    const alias = match[1] || match[2];
+    const spec = match[3];
     strayImports++;
     // Resolve the specifier to an actual module file by suffix match (handles
     // path aliases like @/styles/x.module.css without reading tsconfig).
     const tail = spec.replace(/^.*[/\\]/, '');
     const target =
       moduleFiles.find((mf) => mf.endsWith(spec.replace(/^@?\/?/, ''))) ||
-      moduleFiles.find((mf) => mf.endsWith('/' + tail)) ||
+      moduleFiles.find((mf) => mf.endsWith(`/${tail}`)) ||
       null;
     if (target) importsByModule.get(target).push({ component: sf, alias });
   }
 }
 
+/** Returns the path of `p` relative to the project root. */
 const rel = (p) => relative(ROOT, p);
 
 if (CHECK) {

--- a/.claude/skills/css-modules-to-tailwind/scripts/discover.mjs
+++ b/.claude/skills/css-modules-to-tailwind/scripts/discover.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Discover CSS Modules and the components that import them — or verify a
+// migration is complete. Zero dependencies; run from the project root.
+//
+//   node discover.mjs            List every *.module.{css,scss} + its importers.
+//   node discover.mjs --check    Exit non-zero if any module file/import remains
+//                                (use after migration to prove it's total).
+//   node discover.mjs --json     Machine-readable output for the default mode.
+//
+// "Importers" are found by scanning source files for an import whose specifier
+// ends in .module.css / .module.scss, capturing the local alias (e.g. `styles`,
+// `icon`) so you know what to grep for when rewriting JSX.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, extname } from 'node:path';
+
+const ROOT = process.cwd();
+const CHECK = process.argv.includes('--check');
+const JSON_OUT = process.argv.includes('--json');
+
+const IGNORE = new Set([
+  'node_modules',
+  '.next',
+  'out',
+  'dist',
+  'build',
+  '.git',
+  'coverage',
+]);
+const SOURCE_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const MODULE_RE = /\.module\.s?css$/;
+
+/** Recursively collect files, skipping ignored dirs. */
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (IGNORE.has(name)) continue;
+    const full = join(dir, name);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) walk(full, out);
+    else out.push(full);
+  }
+  return out;
+}
+
+const allFiles = walk(ROOT);
+const moduleFiles = allFiles.filter((f) => MODULE_RE.test(f));
+const sourceFiles = allFiles.filter((f) => SOURCE_EXT.has(extname(f)));
+
+// Map module file path -> [{ component, alias }]
+const importsByModule = new Map(moduleFiles.map((m) => [m, []]));
+// Match: import styles from '...module.css'  /  import * as styles from '...'
+const importRe =
+  /import\s+(?:(\w+)|\*\s+as\s+(\w+))\s+from\s+['"]([^'"]+\.module\.s?css)['"]/g;
+
+let strayImports = 0;
+for (const sf of sourceFiles) {
+  const text = readFileSync(sf, 'utf8');
+  let m;
+  while ((m = importRe.exec(text)) !== null) {
+    const alias = m[1] || m[2];
+    const spec = m[3];
+    strayImports++;
+    // Resolve the specifier to an actual module file by suffix match (handles
+    // path aliases like @/styles/x.module.css without reading tsconfig).
+    const tail = spec.replace(/^.*[/\\]/, '');
+    const target =
+      moduleFiles.find((mf) => mf.endsWith(spec.replace(/^@?\/?/, ''))) ||
+      moduleFiles.find((mf) => mf.endsWith('/' + tail)) ||
+      null;
+    if (target) importsByModule.get(target).push({ component: sf, alias });
+  }
+}
+
+const rel = (p) => relative(ROOT, p);
+
+if (CHECK) {
+  const remainingFiles = moduleFiles.map(rel);
+  if (remainingFiles.length === 0 && strayImports === 0) {
+    console.log(
+      '✓ Migration complete: no *.module.{css,scss} files or imports remain.'
+    );
+    process.exit(0);
+  }
+  console.error('✗ Migration incomplete.');
+  if (remainingFiles.length) {
+    console.error(`\n  ${remainingFiles.length} module file(s) still present:`);
+    for (const f of remainingFiles) console.error(`    - ${f}`);
+  }
+  if (strayImports) {
+    console.error(
+      `\n  ${strayImports} module import(s) still referenced in source.`
+    );
+  }
+  process.exit(1);
+}
+
+const report = moduleFiles.map((mf) => ({
+  file: rel(mf),
+  importers: importsByModule.get(mf).map((i) => ({
+    component: rel(i.component),
+    alias: i.alias,
+  })),
+}));
+
+if (JSON_OUT) {
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(0);
+}
+
+if (report.length === 0) {
+  console.log('No CSS Module files found. Nothing to migrate.');
+  process.exit(0);
+}
+
+console.log(`Found ${report.length} CSS Module file(s):\n`);
+for (const r of report) {
+  console.log(`● ${r.file}`);
+  if (r.importers.length === 0) {
+    console.log(
+      '    (no importers found — possibly dead, verify before deleting)'
+    );
+  }
+  for (const imp of r.importers) {
+    console.log(`    ← ${imp.component}  (as "${imp.alias}")`);
+  }
+  if (r.importers.length > 1) {
+    console.log('    ⚠ shared by multiple components — migrate them together.');
+  }
+  console.log('');
+}
+
+const shared = report.filter((r) => r.importers.length > 1);
+console.log(
+  'Suggested order: migrate leaf/single-importer modules first, shared ones last.'
+);
+if (shared.length) {
+  console.log(
+    `Shared modules to handle carefully: ${shared.map((s) => s.file).join(', ')}`
+  );
+}

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,4 +1,6 @@
 version = 1
 
+exclude_patterns = [".claude/**"]
+
 [[analyzers]]
 name = "javascript"


### PR DESCRIPTION
## Summary

Adds the **css-modules-to-tailwind** Claude Code skill that automates migrating CSS Modules to Tailwind CSS v4.

Contents:
- `SKILL.md` — the skill definition / workflow
- `references/mapping.md`, `references/edge-cases.md`, `references/tailwind-v4-setup.md` — guidance docs
- `scripts/discover.mjs` — discovery helper
- `evals/evals.json` — evaluation cases

This PR is **skill-only**. The actual Tailwind migration it produced is shipped separately.

## Update

Adds a **"Who runs this (recommended agent)"** section to `SKILL.md`: run the migration end-to-end with the `general-purpose` agent on Opus (it needs full Read/Write/Edit/Bash tooling and carries high-risk, compile-clean-regression judgment), and keep the bounded, read-only Phase 3 static-export check delegated to the low-cost `static-export-guardian` agent (`sonnet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)