### PR TITLE
fix(deps): patch high-severity brace-expansion Dependabot alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -797,17 +797,17 @@ baseline-browser-mapping@^2.10.44, baseline-browser-mapping@^2.9.19:
   integrity sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
-  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 


### PR DESCRIPTION
## Summary

Resolves Dependabot alerts #80, #81, and #82 by updating the transitive `brace-expansion` dependency within existing semver ranges:
- `1.1.16 → 1.1.18` (via ESLint's `minimatch@3`)
- `5.0.8 → 5.0.9` (via `@typescript-eslint/typescript-estree`'s `minimatch@10`)

These are dev-only dependencies with patch-level updates containing security fixes. No API-breaking changes or major version collapses.

## Validation

All checks passed:

- ✅ `yarn lint` — ESLint passed
- ✅ `yarn prettier --check .` — Formatting compliant
- ✅ `yarn typecheck` — TypeScript strict mode passed
- ✅ `yarn build` — Static export successful to `out/`
- ✅ `yarn audit --level high` — 0 high/critical vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)