### PR TITLE
fix(deps): patch postcss Dependabot alert GHSA-fxqj-rqcc-2cmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://rodrigocastilho.com/",
   "resolutions": {
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "sharp": "0.35.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,10 +1885,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.12:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.16:
+  version "3.3.17"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.17.tgz#f1c3aa253c52547956a52c50bff754316f61037a"
+  integrity sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2067,12 +2067,12 @@ possible-typed-array-names@^1.0.0, possible-typed-array-names@^1.1.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-postcss@8.4.31, postcss@8.5.18:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+postcss@8.4.31, postcss@8.5.23:
+  version "8.5.23"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
+  integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #83](https://github.com/rodcast/rodcast.github.io/security/dependabot/83).

- Bumps the `postcss` entry in `resolutions` from `8.5.18` → `8.5.23`
- `yarn.lock` refreshed: `postcss@8.5.23`, transitively `nanoid@3.3.17`

## Advisory

| Field | Value |
| --- | --- |
| Advisory | GHSA-fxqj-rqcc-2cmp |
| CVE | CVE-2026-69153 |
| Severity | Medium |
| Vulnerable | `<= 8.5.22` |
| First patched | `8.5.23` |

Incomplete fix of GHSA-6g55-p6wh-862q: an attacker-controlled `sourceMappingURL` can read arbitrary `.map` files when `from` is unset. `8.5.23` is the minimum patched version, so this is the smallest possible upgrade.

## Verification

All four gates pass on Node 24.17.0:

- `yarn lint` — clean
- `yarn prettier --check .` — all files match
- `yarn typecheck` — no errors
- `yarn build` — static export to `out/` succeeded (3/3 pages)

The build logs a Medium fetch failure (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`) — a pre-existing local TLS/cert condition, not related to this change. The API fallback handles it and the export completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)