### PR TITLE
docs: sync documentation with current codebase

### DIFF
--- a/.claude/skills/new-component/SKILL.md
+++ b/.claude/skills/new-component/SKILL.md
@@ -11,7 +11,7 @@ Create a component in `src/components/` paired with a CSS Module in `src/styles/
 ## Conventions (non-negotiable)
 
 - **CSS Modules for all component styles** — never inline styles or `globals.css` for component-scoped rules.
-- **Path aliases only** — `@/styles/*`, `@/components/*`, `@/utils/*`, `@/interfaces/*`. Never relative paths.
+- **Path aliases for cross-directory imports** — `@/styles/*`, `@/components/*`, `@/utils/*`, `@/interfaces/*`. Never `../` traversal. Sibling components in `src/components/` are imported relatively (`./SocialLinks`), matching `Article.tsx` and `Sidebar.tsx`.
 - **Strict TypeScript** — type all props via an explicit `interface`; no `any`.
 - **Design tokens** — use the CSS custom properties already in the modules (`var(--space-x-*)`, `var(--text-*)`, `var(--secondary-color)`, …) rather than hardcoded values.
 - **Accessibility** — semantic HTML, `aria-*`/labels where needed, readable fallback text.
@@ -36,5 +36,5 @@ Create a component in `src/components/` paired with a CSS Module in `src/styles/
    }
    ```
 
-4. Wire it into its parent page/component using the path alias import.
+4. Wire it into its parent: `@/components/<PascalCase>` from a page, or `./<PascalCase>` from a sibling component.
 5. Verify with the `verify-project` skill (lint, Prettier, typecheck, build) before declaring done.

--- a/.claude/skills/verify-project/SKILL.md
+++ b/.claude/skills/verify-project/SKILL.md
@@ -9,7 +9,7 @@ Run the full quality gate defined in `AGENTS.md` → **Verification** and resolv
 
 ## Steps
 
-1. **Activate the correct Node version.** The project requires Node 24.x (see `.nvmrc`). The pre-commit hook fails on the wrong version, so always start here:
+1. **Activate the correct Node version.** The project requires Node 24.x (`.nvmrc` pins `v24.17.0`, and `package.json` declares `engines.node: 24.x`). CI resolves the version from `.nvmrc`, so match it locally before anything else:
 
    ```bash
    nvm use
@@ -23,10 +23,12 @@ Run the full quality gate defined in `AGENTS.md` → **Verification** and resolv
 
    | Command                   | Checks                                                        |
    | ------------------------- | ------------------------------------------------------------- |
-   | `yarn lint`               | ESLint (also enforced by the Husky pre-commit hook)           |
+   | `yarn lint`               | ESLint (also enforced by the Husky pre-commit hook + CI)      |
    | `yarn prettier --check .` | Prettier formatting (pre-commit hook + CI)                    |
-   | `yarn typecheck`          | `tsc --noEmit`, strict mode — must report zero errors         |
+   | `yarn typecheck`          | `tsc --noEmit`, strict mode — must report zero errors (CI)    |
    | `yarn build`              | Static export to `out/` — a build failure means not shippable |
+
+   `.husky/pre-commit` runs the first two (`yarn lint && yarn prettier --check .`); CI runs all four.
 
 3. **Report honestly.** If any step fails, show the failing output, fix the cause, and re-run the whole suite. Do not skip a step or call the task done on a partial pass.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,25 +20,36 @@ Personal website for Rodrigo Castilho.
 src/
   pages/         # Next.js pages (Pages Router)
   components/    # UI components
+  fonts/         # Local Fontello icon font (loaded via next/font/local)
   shared/
     constants/   # External API endpoint URLs
     interfaces/  # TypeScript contracts for API and UI data
     types/       # Ambient type declarations
-    utils/       # Fetch helper, data normalizers
+    utils/       # Fetch helper, data normalizers, WebMCP tool definitions
   styles/        # CSS Modules + global CSS
 public/          # Static assets served at the root
   .well-known/   # API/OAuth/MCP/Agent discovery metadata
   agent/         # Static agent endpoint payloads
   oauth/         # Static OAuth endpoint payloads
-  docs/api/      # Static API docs and OpenAPI contract
+  docs/api/      # Static API docs (HTML) and OpenAPI contract
+  docs/api.md    # Markdown API docs for agents
   api/health     # Static health endpoint payload
+  index.md       # Markdown representation of the homepage
+  auth.md        # Agent registration / auth flow contract
+  llms.txt       # Agent-oriented site index
+  feed.xml       # RSS feed
+  sitemap.xml    # Sitemap
+  robots.txt     # Crawler directives
+  manifest.json  # PWA manifest
+  _headers       # Header rules (non-Pages hosts only — see below)
+  CNAME          # Custom domain for GitHub Pages
 ```
 
 ### Key Files
 
 | File                                  | Role                                                           |
 | ------------------------------------- | -------------------------------------------------------------- |
-| `src/pages/_app.tsx`                  | Global styles, Google Analytics, WebMCP tool registration      |
+| `src/pages/_app.tsx`                  | Global styles, cookie consent, Google Analytics, WebMCP setup  |
 | `src/pages/_document.tsx`             | SEO metadata, Open Graph/Twitter tags, JSON-LD, PWA links      |
 | `src/pages/index.tsx`                 | Main page — fetches data at build time via `getStaticProps`    |
 | `src/shared/types/webmcp.d.ts`        | Ambient WebMCP navigator and tool type declarations            |
@@ -46,12 +57,14 @@ public/          # Static assets served at the root
 | `src/shared/utils/fetch.ts`           | Typed fetch helper with timeout and error handling             |
 | `src/shared/utils/normalizeGitHub.ts` | Normalizes and filters GitHub API responses                    |
 | `src/shared/utils/normalizeMedium.ts` | Normalizes and filters Medium RSS feed responses               |
+| `src/shared/utils/webmcpTools.ts`     | WebMCP tool definitions read from the rendered DOM             |
 | `public/.well-known/api-catalog`      | API catalog for client and agent service discovery             |
 | `public/.well-known/agent-skills/`    | Agent Skills index and capability docs                         |
 | `public/docs/api/openapi.json`        | Public OpenAPI contract for static metadata endpoints          |
 | `next.config.mjs`                     | Next.js config — must preserve static export settings          |
 | `CLAUDE.md`                           | Quick reference for Claude AI (commands, aliases, constraints) |
 | `DESIGN.md`                           | Architecture decisions and rationale                           |
+| `SECURITY.md`                         | Vulnerability reporting policy (mirrors `security.txt`)        |
 
 ---
 
@@ -74,12 +87,13 @@ public/          # Static assets served at the root
 
 ### Tooling
 
-| Tool                | Purpose                                      |
-| ------------------- | -------------------------------------------- |
-| TypeScript (strict) | Type safety (`tsconfig.json`)                |
-| ESLint 9            | Linting (Next.js + React + TypeScript rules) |
-| Prettier            | Code formatting                              |
-| Husky               | Pre-commit hook that runs lint               |
+| Tool                | Purpose                                                   |
+| ------------------- | --------------------------------------------------------- |
+| TypeScript (strict) | Type safety (`tsconfig.json`)                             |
+| ESLint 9            | Linting (Next.js + React + TypeScript rules)              |
+| Prettier            | Code formatting                                           |
+| Husky               | Pre-commit hook that runs lint + Prettier check           |
+| DeepSource          | Static analysis (`.deepsource.toml`, JavaScript analyzer) |
 
 ---
 
@@ -105,8 +119,12 @@ public/          # Static assets served at the root
 
 - **Workflow file:** `.github/workflows/nextjs.yml`
 - **Trigger:** Push to `master` branch, or manual dispatch.
-- **Build output:** Static files in `out/`.
+- **Node version:** taken from `.nvmrc` (`node-version-file`), so CI and local stay in sync.
+- **Pipeline:** install (`yarn install --frozen-lockfile`) → `yarn lint` + `prettier --check .` → `yarn typecheck` → `actions/configure-pages` → `next build` → upload `out/` → deploy.
+- **Build output:** Static files in `out/` (uploaded with `include-hidden-files: true` so `.well-known/` ships).
 - **Deploy target:** GitHub Pages via `actions/deploy-pages`.
+- `actions/configure-pages` runs with `static_site_generator: next`, which injects `basePath` into `next.config.mjs` at build time. It runs **after** the Prettier check because that injection is not Prettier-formatted.
+- `NEXT_PUBLIC_GA_TRACKING_ID` is injected into the build step from an Actions **variable** (Settings → Secrets and variables → Actions → Variables). It is a public GA measurement ID, not a secret.
 - A `vercel.json` file exists but the canonical production deployment is GitHub Pages.
 
 > **Hosting caveat:** GitHub Pages serves static files only — it does **not**
@@ -126,22 +144,27 @@ public/          # Static assets served at the root
 ### Formatting
 
 - 2-space indentation, UTF-8 encoding, trailing newline.
-- Prettier config: single quotes, semicolons, print width 80.
+- Prettier config (`.prettierrc`): single quotes, semicolons, print width 80, `trailingComma: es5`, always-parenthesized arrow params.
 
 ### Imports
 
-- Use TypeScript path aliases (`@/*`, `@/components/*`, `@/utils/*`, etc.) instead of relative paths.
+- Use TypeScript path aliases (`@/*`, `@/components/*`, `@/utils/*`, etc.) for modules outside the current directory — never `../` traversal.
+- Sibling files within the same directory are imported relatively, matching the existing code (e.g. `./SocialLinks` inside `src/components/`, `./fetch` inside `src/shared/utils/`).
+- Exception: `next/font/local` requires a real relative asset path, so `SocialLinks.tsx` loads the icon font as `../fonts/fontello.woff2`.
 
 ### Data Flow
 
 - All external API data must be normalized through the appropriate utility before being passed to components.
+- `getStaticProps` fetches both sources with `Promise.allSettled` so one failing API cannot blank the other; a rejected source becomes an empty array.
 - If an API contract changes, update both the interface in `src/shared/interfaces/` and its corresponding normalizer together.
 
 ### Discovery Metadata
 
-- Keep `.well-known` discovery documents internally consistent (`api-catalog`, `agent-card.json`, `mcp.json`, `mcp/server-card.json`, OAuth/OIDC metadata, and agent-skills index).
-- When updating any `public/.well-known/agent-skills/*.md` file, refresh the matching `sha256` entry in `public/.well-known/agent-skills/index.json`.
+- Keep `.well-known` discovery documents internally consistent (`api-catalog`, `agent-card.json`, `mcp.json`, `mcp/server-card.json`, `ai-plugin.json`, OAuth/OIDC metadata, and agent-skills index).
+- When updating any `public/.well-known/agent-skills/*.md` file, refresh the matching `sha256` entry in `public/.well-known/agent-skills/index.json` (`shasum -a 256 <file>`).
+- Keep the WebMCP tool names in `src/shared/utils/webmcpTools.ts` in sync with the skill IDs in `agent-card.json` and the tool list in `agent-skills/webmcp-tools.md`.
 - Preserve API discovery links exposed in `src/pages/_document.tsx` (the discovery surface honored on GitHub Pages) and keep them consistent with the `Link` header in `public/_headers`/`vercel.json` (used only on non-Pages hosts).
+- The `check-discovery-consistency` skill (`.claude/skills/`) audits all of the above.
 
 ### Error Handling
 
@@ -202,18 +225,24 @@ These settings must not be changed. Violating them will break the production bui
 ### `next.config.mjs` — required options
 
 ```js
-output: 'export'; // Enables static HTML export
-images: {
-  unoptimized: true;
-} // Required for static export (no image optimization server)
-trailingSlash: true; // Required for correct GitHub Pages routing
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export', // Enables static HTML export
+  trailingSlash: true, // Required for correct GitHub Pages routing
+  images: {
+    unoptimized: true, // Required for static export (no image optimization server)
+  },
+};
 ```
 
 ### Quality Gate
 
-- The pre-commit hook (`.husky/pre-commit`) runs lint automatically.
-- There is no automated test suite; lint is the enforced baseline quality check.
+- The pre-commit hook (`.husky/pre-commit`) runs `yarn lint && yarn prettier --check .` and fails the commit on any error.
+- CI additionally runs `yarn typecheck` and the static build.
+- There is no automated test suite; lint, formatting, typecheck, and a clean static export are the enforced baseline quality checks.
 
 ### Environment Variables
 
-- `NEXT_PUBLIC_GA_TRACKING_ID` — Google Analytics tracking ID (injected at build time).
+- `NEXT_PUBLIC_GA_TRACKING_ID` — Google Analytics measurement ID, read at build time (see `.env.example` for the local template).
+  - Optional. When it is unset, `_app.tsx` renders neither the `CookieConsent` banner nor `GoogleAnalytics`, and `_document.tsx` skips the Google Consent Mode defaults script.
+  - In CI it comes from the `NEXT_PUBLIC_GA_TRACKING_ID` Actions variable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ Quick reference for Claude AI. The full project guide (commands, constraints, co
 ## Claude-Specific Notes
 
 - `yarn dev` sets `NODE_TLS_REJECT_UNAUTHORIZED=0` (local-only TLS bypass for development).
-- CSS Modules for all component styles; globals only in `src/styles/globals.css`.
+- CSS Modules for all component styles; globals only in `src/styles/globals.css` (resets, CSS custom properties, and a few a11y utilities such as `.sr-only`).
+- `.mcp.json` registers the `next-devtools` MCP server for this project.
+- Project skills live in `.claude/skills/` (`verify-project`, `check-discovery-consistency`, `new-component`); `.claude/agents/static-export-guardian.md` reviews diffs for static-export breakage.
 
 ## Path Aliases (tsconfig.json)
 
@@ -30,13 +32,14 @@ Quick reference for Claude AI. The full project guide (commands, constraints, co
 | `@/types/*`      | `src/shared/types/*`      |
 | `@/utils/*`      | `src/shared/utils/*`      |
 
-Always use aliases — never relative paths.
+Use aliases for anything outside the current directory — never `../` traversal. Same-directory siblings are imported relatively (`./SocialLinks`), and `next/font/local` asset paths must stay relative.
 
 ## Data Flow
 
 ```text
 getStaticProps (build time)
-  → fetchData (src/shared/utils/fetch.ts)
+  → Promise.allSettled([fetchData(GITHUB_API), fetchData(MEDIUM_API)])
+      (src/shared/utils/fetch.ts — 5s timeout; rejected source → [])
   → normalizeGitHub / normalizeMedium (src/shared/utils/)
-  → Page props → Article component
+  → Page props → Article (next/dynamic) → GitHub + Medium
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,23 +16,29 @@ The deployable artifact is the generated `out/` directory. Any local verificatio
 
 **Rationale:** GitHub API and the `rss2json` Medium proxy do not require authentication or personalization. Fetching at build time means the deployed HTML already contains the data, avoids client-side API keys, and reduces exposure of rate-limited endpoints to end users.
 
-A 5-second timeout in `fetchData` prevents build hangs. If either API call fails, the page renders with empty arrays rather than crashing.
+A 5-second timeout in `fetchData` prevents build hangs. The two sources are fetched with `Promise.allSettled`, so a failure is isolated per source: the rejection is logged and that source becomes an empty array while the other still renders.
 
 ## Component Structure
 
 ```text
 Page (index.tsx)
-├── Header         — name, title
-├── Toggle         — light/dark mode
-├── Sidebar        — avatar, bio, social links
-├── Article        — GitHub repos + Medium articles
-│   ├── GitHub     — repo cards (wrapped in ErrorBoundary → ApiErrorFallback)
-│   └── Medium     — article cards (wrapped in ErrorBoundary → ApiErrorFallback)
-└── Footer
+├── Header             — h1 logo + in-page nav (#about, #github-projects, #medium-articles)
+├── Toggle             — light/dark mode
+├── Sidebar            — id="about"; photo, bio
+│   └── SocialLinks    — GitHub, Twitter, LinkedIn, Medium (Fontello icon font)
+├── Article            — GitHub repos + Medium articles
+│   ├── GitHub         — id="github-projects" (wrapped in ErrorBoundary → ApiErrorFallback)
+│   └── Medium         — id="medium-articles" (wrapped in ErrorBoundary → ApiErrorFallback)
+└── Footer             — RSS, sitemap, source links
 
 App (_app.tsx)
-└── Registers WebMCP tools through `navigator.modelContext` and `document.modelContext`, retrying briefly while those APIs initialize
+├── Registers WebMCP tools through `navigator.modelContext` and `document.modelContext`,
+│   retrying up to 5 times at 500ms while those APIs initialize
+└── CookieConsent + GoogleAnalytics — rendered only when NEXT_PUBLIC_GA_TRACKING_ID is set
 ```
+
+The section `id`s above are load-bearing: `Header` links to them, and the WebMCP tools in
+`src/shared/utils/webmcpTools.ts` read the DOM through those same selectors.
 
 `Article` is loaded with `next/dynamic` to defer its JS bundle — it is the heaviest component and not needed for the initial paint.
 
@@ -47,6 +53,8 @@ App (_app.tsx)
 The site exposes static discovery metadata under `public/.well-known/`. The main entry points are the API catalog, MCP metadata, agent card, and agent skills index; related OAuth/OIDC, JWKS, AI plugin, HTTP Message Signatures, and security documents live alongside them.
 
 These are committed static JSON/text files under `public/`. They require no server. When updating any `agent-skills/*.md`, regenerate the `sha256` in `agent-skills/index.json`.
+
+**WebMCP tools** are the one dynamic part of this surface: `src/shared/utils/webmcpTools.ts` is the single source of truth, and it reads the rendered DOM rather than re-fetching the APIs. It currently defines `get-profile-summary`, `navigate-to-section`, `list-github-projects`, and `list-medium-articles`. Those names must stay aligned with the skill IDs in `agent-card.json` and the tool list in `agent-skills/webmcp-tools.md`.
 
 **Host limitation:** discovery here relies on static files and the `<link>` tags in `_document.tsx`. The HTTP-header layer (`Link`, `Vary`, `Cache-Control`, and `Accept: text/markdown` negotiation defined in `vercel.json` and `public/_headers`) is **not honored by GitHub Pages** — it applies only if the site is served from Vercel/Cloudflare Pages/Netlify. On GitHub Pages, fetch markdown directly at `/index.md`.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ yarn dev
 
 ## Environment
 
-- `NEXT_PUBLIC_GA_TRACKING_ID` (optional): Enables Google Analytics when set at build time.
+Copy `.env.example` to `.env.local` and fill in what you need.
+
+- `NEXT_PUBLIC_GA_TRACKING_ID` (optional): Google Analytics measurement ID, read at build time. When it is unset, neither the cookie consent banner nor Google Analytics is rendered. In CI it comes from a GitHub Actions variable of the same name.
 
 ## Development Workflow
 
@@ -50,19 +52,31 @@ yarn dev
 
 - Static export via Next.js (`output: 'export'`).
 - The canonical deployment artifact is the static `out/` directory.
-- Deployment runs through GitHub Actions workflow `.github/workflows/nextjs.yml`.
+- Deployment runs through GitHub Actions workflow `.github/workflows/nextjs.yml`, which runs lint, the Prettier check, and typecheck before building.
 - Production deploys are triggered by pushes to `master` (and manual workflow dispatch).
 - When validating the exported site locally, serve `out/` with a static file server.
+- Custom domain: `public/CNAME` (`rodrigocastilho.com`).
 
 ## Project Conventions
 
 - Keep these static export constraints in `next.config.mjs`: `output: 'export'`, `trailingSlash: true`, and `images.unoptimized: true`.
 - Data is fetched at build time from GitHub and Medium.
 - Normalize external API responses before passing data to components (`src/shared/utils/normalizeGitHub.ts` and `src/shared/utils/normalizeMedium.ts`).
-- Use TypeScript path aliases from `tsconfig.json` (for example `@/components/*`, `@/utils/*`) instead of relative imports.
+- Use TypeScript path aliases from `tsconfig.json` (for example `@/components/*`, `@/utils/*`) for cross-directory imports; same-directory siblings are imported relatively.
+- Component styles use CSS Modules in `src/styles/`; only resets, CSS custom properties, and a few accessibility utilities live in `globals.css`.
+- Branch and open a pull request for every change — never commit to `master` (see `AGENTS.md` → Git Workflow).
 
 ## API and Discovery
 
 - API overview: `public/docs/api.md`
 - OpenAPI contract: `public/docs/api/openapi.json`
+- Agent registration contract: `public/auth.md`
 - Static discovery metadata lives under `public/.well-known/`, including the API catalog, MCP metadata, OAuth/OIDC metadata, agent card, and agent skills index.
+- GitHub Pages serves static files only, so the `Link`/`Vary` header rules in `public/_headers` and the `vercel.json` rewrites are inactive in production. Fetch `/index.md` directly instead of relying on `Accept: text/markdown`.
+
+## Further Documentation
+
+- `AGENTS.md` — full project guide: structure, commands, conventions, verification, Git workflow.
+- `DESIGN.md` — architecture decisions and rationale.
+- `CLAUDE.md` — Claude-specific quick reference.
+- `SECURITY.md` — vulnerability reporting policy.

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -27,7 +27,7 @@
       "type": "tools",
       "description": "Exposes WebMCP tools for profile and content retrieval.",
       "url": "https://rodrigocastilho.com/.well-known/agent-skills/webmcp-tools.md",
-      "sha256": "bbd14e6597016291385af6c5e22d4fcfc7f0fe9f6bb12928e3e5082360ee869d"
+      "sha256": "682b0cb043d5518741cb20f94591f3d9849d44eca259fe9df92c5568e3075276"
     },
     {
       "name": "web-bot-auth",

--- a/public/.well-known/agent-skills/webmcp-tools.md
+++ b/public/.well-known/agent-skills/webmcp-tools.md
@@ -1,9 +1,23 @@
 # WebMCP Tools
 
-Expose key profile site actions through the WebMCP browser integration.
+Expose key profile site actions through the WebMCP browser integration. The tools
+are registered on the homepage via `navigator.modelContext` /
+`document.modelContext` and read the rendered page, so they reflect what is
+currently on screen.
 
 ## Tools
 
-- `getProfileSummary`: Returns owner profile overview.
-- `listLatestGitHubRepos`: Returns latest repository metadata.
-- `listLatestArticles`: Returns latest article metadata.
+- `get-profile-summary`: Returns the visible profile summary and social links
+  from the about section. No input.
+- `navigate-to-section`: Scrolls the page to a known section. Required input
+  `section`, one of `about`, `github-projects`, `medium-articles`.
+- `list-github-projects`: Returns the GitHub repositories rendered in the
+  projects section. Optional input `limit` (1-20, default 6).
+- `list-medium-articles`: Returns the Medium articles rendered in the articles
+  section. Optional input `limit` (1-10, default 5).
+
+## Notes
+
+- All tools except `navigate-to-section` are annotated `readOnlyHint: true`.
+- Tool IDs match the `skills[].id` values in
+  `/.well-known/agent-card.json`.

--- a/public/auth.md
+++ b/public/auth.md
@@ -41,6 +41,7 @@ Response shape (read the `agent_auth` block in full):
   "issuer": "https://rodrigocastilho.com",
   "token_endpoint": "https://rodrigocastilho.com/oauth/token",
   "revocation_endpoint": "https://rodrigocastilho.com/oauth/revoke",
+  "jwks_uri": "https://rodrigocastilho.com/.well-known/jwks.json",
   "grant_types_supported": [
     "urn:ietf:params:oauth:grant-type:jwt-bearer",
     "urn:workos:agent-auth:grant-type:claim"
@@ -51,6 +52,7 @@ Response shape (read the `agent_auth` block in full):
     "identity_endpoint": "https://rodrigocastilho.com/agent/identity/register",
     "register_uri": "https://rodrigocastilho.com/agent/identity/register",
     "claim_endpoint": "https://rodrigocastilho.com/agent/identity/claim",
+    "events_endpoint": "https://rodrigocastilho.com/agent/event/notify",
     "identity_types_supported": ["anonymous", "service_auth"],
     "anonymous": {
       "credential_types_supported": ["access_token"],

--- a/public/docs/api.md
+++ b/public/docs/api.md
@@ -1,16 +1,44 @@
 # Rodrigo Castilho API Documentation
 
-This site exposes static metadata for discovery by automated clients.
+This site is a statically exported Next.js application hosted on GitHub Pages. It
+exposes static metadata for discovery by automated clients. Every endpoint below
+is a static file served with `GET`; there is no request-time server.
 
 ## Discovery Endpoints
 
-- `/.well-known/api-catalog` - API directory for clients and agents.
+- `/.well-known/api-catalog` - RFC 9727 linkset directory for clients and agents.
+- `/.well-known/agent-card.json` - Agent card describing the available skills.
+- `/.well-known/agent-skills/index.json` - Agent Skills index (each entry carries a `sha256`).
+- `/.well-known/mcp.json` - MCP capability and schema metadata.
+- `/.well-known/mcp/server-card.json` - MCP server discovery metadata.
+- `/.well-known/ai-plugin.json` - AI plugin manifest pointing at the OpenAPI contract.
+
+## Authentication Endpoints
+
 - `/.well-known/openid-configuration` - OpenID Connect metadata.
 - `/.well-known/oauth-authorization-server` - OAuth authorization server metadata.
 - `/.well-known/oauth-protected-resource` - OAuth protected resource metadata.
-- `/.well-known/mcp/server-card.json` - MCP server discovery metadata.
+- `/.well-known/jwks.json` - JWKS URI advertised by the authorization server metadata.
+- `/auth.md` - Agent registration and token-exchange contract.
+
+## Identity and Security
+
+- `/.well-known/http-message-signatures-directory` - Web Bot Auth Ed25519 key directory.
+- `/.well-known/security.txt` - RFC 9116 vulnerability reporting contact.
 
 ## API Contract
 
-- OpenAPI JSON: `/docs/api/openapi.json`
-- Health endpoint: `/api/health`
+- OpenAPI JSON: `/docs/api/openapi.json` (OpenAPI 3.1)
+- Human-readable docs: `/docs/api/`
+- Health endpoint: `/api/health` — returns `{"status":"ok"}`
+
+## Agent-Friendly Content
+
+- `/llms.txt` - Site index for LLM clients.
+- `/index.md` - Markdown representation of the homepage.
+- `/feed.xml` - RSS feed.
+- `/sitemap.xml` - Indexable URLs.
+
+> On GitHub Pages, `Accept: text/markdown` content negotiation on `/` is not
+> active — the `vercel.json` rewrite and `public/_headers` rules only apply on
+> hosts that honor them. Fetch `/index.md` directly instead.


### PR DESCRIPTION
## Summary

- Audits all 18 `*.md` files against the actual source, config, and CI, and corrects what had drifted.
- Fixes one defect that misleads real consumers: the published WebMCP tool list advertised three tool names that do not exist, so any agent reading `/.well-known/agent-skills/webmcp-tools.md` would call the wrong tools.
- Documentation only — no application behavior changed.

## Changes

**Incorrect published metadata**

- `webmcp-tools.md` advertised `getProfileSummary` / `listLatestGitHubRepos` / `listLatestArticles`. The real tools in `src/shared/utils/webmcpTools.ts` are `get-profile-summary`, `navigate-to-section`, `list-github-projects`, `list-medium-articles` (matching `agent-card.json`, which was already correct). Rewrote with real names, input schemas and defaults, and refreshed the `sha256` in `agent-skills/index.json`.
- `public/auth.md`'s authorization-server sample was missing `jwks_uri` and `events_endpoint`, both present in the served `oauth-authorization-server` document.
- `public/docs/api.md` listed 5 of ~15 discovery endpoints; now covers the full surface, grouped, with the GitHub Pages negotiation caveat.

**Broken example**

- `AGENTS.md`'s `next.config.mjs` snippet used semicolons inside an object literal — not valid JS. Replaced with the real `nextConfig` object shape.

**Claims that contradicted the code**

- The pre-commit hook was documented as "runs lint"; it runs `yarn lint && yarn prettier --check .`, and CI additionally runs typecheck and the static build.
- "Always use aliases — never relative paths" is contradicted by `Article.tsx` / `Sidebar.tsx` (`./GitHub`, `./SocialLinks`) and by `next/font/local`, which requires a real relative asset path. Documented the convention the code actually follows.
- The `verify-project` skill claimed the pre-commit hook fails on the wrong Node version; it performs no such check.

**Stale inventories**

- Added `src/fonts/`, `webmcpTools.ts`, the `public/` agent and SEO surface (`index.md`, `auth.md`, `llms.txt`, `docs/api.md`, `feed.xml`, `sitemap.xml`, `manifest.json`, `_headers`, `CNAME`), DeepSource, and the next-devtools MCP server.
- Completed the `DESIGN.md` component tree (`SocialLinks`, `CookieConsent`) and recorded that the section `id`s are load-bearing for both the `Header` anchors and the WebMCP DOM selectors.
- Documented `Promise.allSettled` per-source fetch isolation and the real CI pipeline order, including why `configure-pages` runs after the Prettier check.

## Test plan

- [x] `yarn lint && yarn prettier --check . && yarn typecheck && yarn build` passes
- [x] All five `agent-skills/*.md` sha256 values match `index.json`, verified in the exported `out/`
- [x] Every file path referenced across all `*.md` files exists; the one relative link resolves
- [ ] Reviewer sanity-check: `/.well-known/agent-skills/webmcp-tools.md` matches the `agent-card.json` skill IDs

## Follow-ups (not in this PR)

Two real issues found during the audit that need code changes, so they were deliberately left out:

- `webmcpTools.ts:19` reads the profile description from `about h3`, but `Sidebar.tsx` renders the bio in a `<p>`, so `get-profile-summary` returns an empty `description` at runtime.
- `public/index.md` hardcodes `dateModified: "2026-06-20"` while `_document.tsx` generates it from the build date. Any literal goes stale again on the next deploy; the durable fix is generating that block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
